### PR TITLE
Minor update to usage of auth input arguments

### DIFF
--- a/src/recastatlas/subcommands/auth.py
+++ b/src/recastatlas/subcommands/auth.py
@@ -91,7 +91,7 @@ def setup(answer):
     click.secho("export {}='{}'".format(envvar["init_load"], token))
     click.secho("export {}='{}'".format(envvar["registry_host"], registry))
     click.secho("export {}='{}'".format(envvar["registry_user"], username))
-    click.secho("export {}='{}'".format(envvar["registry_pass"], token))
+    click.secho("export {}='{}'".format(envvar["registry_pass"], password))
     click.secho(
         "docker login -u ${} -p ${} ${}".format(
             envvar["registry_user"], envvar["registry_pass"], envvar["registry_host"]


### PR DESCRIPTION
The command `eval "$(recast auth setup -a $RECAST_USER -a $RECAST_PASS -a $RECAST_TOKEN -a default)"` was failing with the following error:

```bash
Error response from daemon: Get https://gitlab-registry.cern.ch/v2/: unauthorized: HTTP Basic: Access denied
```

This authorization error seems to be resolved by assigning the user-input `$RECAST_PASS` password - rather than the user-input `$RECAST_TOKEN` - to the variable `registry_pass` in `auth.py`. 

The `eval` command above now succeeds with:

```bash
Login Succeeded
``` 