### PR TITLE
ci: Fix Python tests CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,17 @@
-name: CI/CD
+name: CI
 
 on:
   push:
+    branches:
+    - master
   pull_request:
+    branches:
+    - master
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'
+  workflow_dispatch:
+
 
 jobs:
   test:
@@ -16,17 +22,25 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@master
+    - name: Checkout code
+      uses: actions/checkout@v2
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+
+    - name: Install external dependencies
       run: |
+        sudo apt-get update -y
         sudo apt-get install -y graphviz libgraphviz-dev
+
+    - name: Install Python dependencies
+      run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install -q --no-cache-dir -e .[develop,local]
-        pip list
+        python -m pip --quiet install --no-cache-dir .[develop,local]
+        python -m pip list
+
     - name: Run unit tests
       run: |
         python -m pytest tests

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RECAST for ATLAS
 
-[![Build Status](https://travis-ci.org/recast-hep/recast-atlas.svg?branch=master)](https://travis-ci.org/recast-hep/recast-atlas)
+[![CI](https://github.com/recast-hep/recast-atlas/actions/workflows/ci.yml/badge.svg)](https://github.com/recast-hep/recast-atlas/actions/workflows/ci.yml?query=branch%3Amaster)
 [![PyPI version](https://badge.fury.io/py/recast-atlas.svg)](https://badge.fury.io/py/recast-atlas)
 
 ATLAS tools to facilitate integration of ATLAS anlayses into RECAST

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,13 @@ setup(
       'adage==0.10.1',
       'yadage-schemas==0.10.6',
       'packtivity==0.14.23',
-      'yadage[viz]==0.20.1',
+      'yadage==0.20.1',  # yadage[viz] breaks so install following manually
+      'pydot',  # from yadage[viz] extra
+      'pygraphviz'  # from yadage[viz] extra
     ],
     'kubernetes': [
       'kubernetes==9.0.0'
-    ], 
+    ],
     'reana': [
       'reana-client==0.7.5'
     ]


### PR DESCRIPTION
Requires PR #44 to go in first.

---

The CI is failing as the default database cache that the base images have are out of sync with the package lists for Ubuntu and also because of conflicts with `yadage[viz]`. Running `apt-get update` first will retrieve the latest package lists and ensure that `apt-get install` will proceed. Also manually install the components of `yadage[viz]`. Additionally update the build status badge to reflect the state of GitHub Actions on `master`.

[![CI](https://github.com/recast-hep/recast-atlas/actions/workflows/ci.yml/badge.svg)](https://github.com/recast-hep/recast-atlas/actions/workflows/ci.yml?query=branch%3Amaster)