### PR TITLE
ci: Split out workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,27 +27,6 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install -q --no-cache-dir -e .[develop,local]
         pip list
-    - name: Lint with Pyflakes
-      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
-      run: |
-        pyflakes src
-    - name: Lint with Black
-      if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
-      run: |
-        black src
     - name: Run unit tests
       run: |
         python -m pytest tests
-    - name: Docker Build
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        docker build -t recast/recastatlas:ci -f docker/Dockerfile $PWD
-    - name: Run
-      if: matrix.os == 'ubuntu-latest'
-      env:
-        RECAST_IMAGE: recast/recastatlas:ci
-      run: |
-        docker info
-        recast --help
-        recast run testing/busyboxtest --backend local
-

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,86 @@
+name: Docker Images
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+  pull_request:
+    branches:
+    - master
+  schedule:
+    - cron:  '1 0 * * *'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  docker:
+    name: Build, test, and publish Docker images to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=recast/recastatlas
+          VERSION=latest
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/pull/* ]]; then
+            VERSION=pr-${{ github.event.number }}
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          TAGS="$TAGS,${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          # Releases also have GITHUB_REFs that are tags, so reuse VERSION
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable"
+          fi
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      # - name: Login to DockerHub
+      #   if: github.event_name != 'pull_request'
+      #   uses: docker/login-action@v1
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Test build
+        id: docker_build_test
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/Dockerfile
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          load: true
+          push: false
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build_test.outputs.digest }}
+
+      - name: List built images
+        run: docker images
+
+      - name: Check basic run works
+        run: >-
+          docker run --rm
+          recast/recastatlas:sha-${GITHUB_SHA::8}
+          -c "recast --help; recast run testing/busyboxtest --backend local"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+    - master
+  workflow_dispatch:
+
+jobs:
+  lint:
+
+    name: Lint Codebase
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip --quiet install --upgrade .[develop]
+        python -m pip list
+
+    - name: Lint with Pyflakes
+      run: |
+        pyflakes src
+
+    - name: Lint with Black
+      run: |
+        black --check --diff --verbose .


### PR DESCRIPTION
As part of fixing the CI across a series of PRs start in this one by seperating out the CI into 3 distinct workflows: Python testing, linting, and Docker tests.

These workflows will all fail at the moment, which is expected as this PR just splits out failing workflows. The Python testing workflow will be fixed in PR #43 which will be rebased on top of this PR. Other PRs for fixing linting and Docker building can follow.

**Suggested squash and merge commit message**
```
* Split the CI workflows into seperated Python testing, linting, and Docker building workflows
   - These workflows currently fail but that is expected
```