### PR TITLE
chore: Apply linting with Black and flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+# E501: line too long
+extend-ignore = E501
+count = True
+statistics = True

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,9 +27,9 @@ jobs:
         python -m pip --quiet install --upgrade .[develop]
         python -m pip list
 
-    - name: Lint with Pyflakes
+    - name: Lint with flake8
       run: |
-        pyflakes src
+        python -m flake8 .
 
     - name: Lint with Black
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,6 @@
 [tool.black]
 line-length = 88
-py36 = false  # Python 2 is still supported
 skip-string-normalization = true
-skip-numeric-underscore-normalization = true  # Python 2 is still supported
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
   extras_require =  {
     'develop': {
       'pytest',
-      'pyflakes',
+      'flake8>=3.9.0',
       'black'
     },
     'local': [

--- a/setup.py
+++ b/setup.py
@@ -9,48 +9,39 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md
     long_description = readme_md.read()
 
 setup(
-  name = 'recast-atlas',
-  version = '0.1.7',
-  description = 'RECAST for ATLAS at the LHC',
-  url = '',
-  author = 'Lukas Heinrich',
-  author_email = 'lukas.heinrich@cern.ch',
-  package_dir={'': 'src'},
-  packages=find_packages(where='src'),
-  include_package_data = True,
-  install_requires = [
-    'click',
-    'jsonschema',
-    'pyyaml',
-    'yadage-schemas==0.10.6',
-  ],
-  extras_require =  {
-    'develop': {
-      'pytest',
-      'flake8>=3.9.0',
-      'black'
+    name='recast-atlas',
+    version='0.1.7',
+    description='RECAST for ATLAS at the LHC',
+    url='',
+    author='Lukas Heinrich',
+    author_email='lukas.heinrich@cern.ch',
+    package_dir={'': 'src'},
+    packages=find_packages(where='src'),
+    include_package_data=True,
+    install_requires=[
+        'click',
+        'jsonschema',
+        'pyyaml',
+        'yadage-schemas==0.10.6',
+    ],
+    extras_require={
+        'develop': {'pytest', 'flake8>=3.9.0', 'black'},
+        'local': [
+            'pydotplus==2.0.2',
+            'adage==0.10.1',
+            'yadage-schemas==0.10.6',
+            'packtivity==0.14.23',
+            'yadage==0.20.1',  # yadage[viz] breaks so install following manually
+            'pydot',  # from yadage[viz] extra
+            'pygraphviz',  # from yadage[viz] extra
+        ],
+        'kubernetes': ['kubernetes==9.0.0'],
+        'reana': ['reana-client==0.7.5'],
     },
-    'local': [
-      'pydotplus==2.0.2',
-      'adage==0.10.1',
-      'yadage-schemas==0.10.6',
-      'packtivity==0.14.23',
-      'yadage==0.20.1',  # yadage[viz] breaks so install following manually
-      'pydot',  # from yadage[viz] extra
-      'pygraphviz'  # from yadage[viz] extra
-    ],
-    'kubernetes': [
-      'kubernetes==9.0.0'
-    ],
-    'reana': [
-      'reana-client==0.7.5'
-    ]
-  },
-  entry_points = {
-      'console_scripts': [
-          'recast=recastatlas.cli:recastatlas',
-      ],
-  },
-  dependency_links = [
-  ],
+    entry_points={
+        'console_scripts': [
+            'recast=recastatlas.cli:recastatlas',
+        ],
+    },
+    dependency_links=[],
 )

--- a/src/recastatlas/backends/__init__.py
+++ b/src/recastatlas/backends/__init__.py
@@ -57,7 +57,7 @@ def get_shell_packtivity(name, spec, backend):
         command, dockerconfig = setup_docker()
         script = """\
 mkdir -p ~/.docker
-echo '{dockerconfig}' > ~/.docker/config.json 
+echo '{dockerconfig}' > ~/.docker/config.json
 {command}
         """.format(
             dockerconfig=json.dumps(dockerconfig), command=shellcmd

--- a/src/recastatlas/backends/__init__.py
+++ b/src/recastatlas/backends/__init__.py
@@ -11,18 +11,21 @@ log = logging.getLogger(__name__)
 BACKENDS = {}
 try:
     from .reana import ReanaBackend
+
     BACKENDS['reana'] = ReanaBackend()
 except (ImportError, exceptions.BackendNotAvailableException):
     pass
 
 try:
     from .kubernetes import KubernetesBackend
+
     BACKENDS['kubernetes'] = KubernetesBackend()
 except (ImportError, exceptions.BackendNotAvailableException):
     pass
 
 try:
     from .local import LocalBackend
+
     BACKENDS['local'] = LocalBackend()
 except (ImportError, exceptions.BackendNotAvailableException):
     pass
@@ -30,6 +33,7 @@ except (ImportError, exceptions.BackendNotAvailableException):
 try:
     from .docker import DockerBackend
     from .docker import setup_docker
+
     BACKENDS['docker'] = DockerBackend()
 except (ImportError, exceptions.BackendNotAvailableException):
     pass
@@ -37,13 +41,15 @@ except (ImportError, exceptions.BackendNotAvailableException):
 
 def get_shell_packtivity(name, spec, backend):
     workname = name
-    shellcmd = "packtivity-util shell {spec} -t {toplevel}  -w {workname} {readdirs}".format(
-        spec=spec["spec"],
-        toplevel=spec["toplevel"],
-        workname=workname,
-        readdirs=" ".join(
-            ["-r {}".format(os.path.realpath(d)) for d in spec.get("data", [])]
-        ),
+    shellcmd = (
+        "packtivity-util shell {spec} -t {toplevel}  -w {workname} {readdirs}".format(
+            spec=spec["spec"],
+            toplevel=spec["toplevel"],
+            workname=workname,
+            readdirs=" ".join(
+                ["-r {}".format(os.path.realpath(d)) for d in spec.get("data", [])]
+            ),
+        )
     )
     if backend == "local":
         return subprocess.check_output(shlex.split(shellcmd)).decode("ascii")
@@ -64,20 +70,25 @@ def run_sync_packtivity(name, spec, backend):
     assert backend in ["local", "docker"]
     BACKENDS[backend].run_packtivity(name, spec)
 
+
 def run_sync(name, spec, backend):
     assert backend in ["local", "docker"]
-    BACKENDS[backend].run_workflow(name,spec)
+    BACKENDS[backend].run_workflow(name, spec)
+
 
 def run_async(name, spec, backend):
     assert backend in ["kubernetes", "reana"]
     return BACKENDS[backend].submit(name, spec)
 
+
 def check_async(name, backend):
     assert backend in ["kubernetes", "reana"]
     return BACKENDS[backend].check_workflow(name)
 
+
 def check_backend(backend):
     return BACKENDS[backend].check_backend()
-    
+
+
 def install_backend(backend):
     pass

--- a/src/recastatlas/backends/docker.py
+++ b/src/recastatlas/backends/docker.py
@@ -10,6 +10,7 @@ import yaml
 
 log = logging.getLogger(__name__)
 
+
 def setup_docker():
     backend = "docker"
     cwd = os.getcwd()
@@ -88,12 +89,13 @@ def setup_docker():
             }
         }
     return command, dockerconfig
-    
+
+
 class DockerBackend:
-    def run_workflow(self,name,spec):
+    def run_workflow(self, name, spec):
         backend_config = config.backends['docker']["fromstring"]
 
-        spec["backend"] = spec.get('backend',backend_config)
+        spec["backend"] = spec.get('backend', backend_config)
         command, dockerconfig = setup_docker()
 
         script = """\
@@ -107,8 +109,8 @@ class DockerBackend:
         )
         command += ["sh", "-c", textwrap.dedent(script)]
         subprocess.check_call(command)
-        
-    def run_packtivity(self,name,spec):
+
+    def run_packtivity(self, name, spec):
         workname = name
         command, dockerconfig = setup_docker()
         script = """\

--- a/src/recastatlas/backends/docker.py
+++ b/src/recastatlas/backends/docker.py
@@ -100,8 +100,8 @@ class DockerBackend:
 
         script = """\
         mkdir -p ~/.docker
-        echo '{dockerconfig}' > ~/.docker/config.json 
-        cat << 'EOF' | yadage-run -f - 
+        echo '{dockerconfig}' > ~/.docker/config.json
+        cat << 'EOF' | yadage-run -f -
         {spec}
         EOF
         """.format(
@@ -118,7 +118,7 @@ mkdir -p ~/.docker
 cat << 'EOF' > /tmp/pars.yml
 {pars}
 EOF
-echo '{dockerconfig}' > ~/.docker/config.json 
+echo '{dockerconfig}' > ~/.docker/config.json
 packtivity-run {spec} -t {toplevel} /tmp/pars.yml -w {workname} {readdirs}
         """.format(
             spec=spec["spec"],
@@ -142,6 +142,6 @@ packtivity-run {spec} -t {toplevel} /tmp/pars.yml -w {workname} {readdirs}
                 ["docker", "info"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
             return rc == 0
-        except:
+        except Exception:  # TODO: Specify Exception type
             pass
         return False

--- a/src/recastatlas/backends/kubernetes.py
+++ b/src/recastatlas/backends/kubernetes.py
@@ -1,5 +1,5 @@
-
 import json
+
 
 class KubernetesBackend:
     def submit(self, name, spec):
@@ -57,4 +57,4 @@ class KubernetesBackend:
             pass
         except k8sclient.rest.ApiException:
             pass
-        return False        
+        return False

--- a/src/recastatlas/backends/kubernetes.py
+++ b/src/recastatlas/backends/kubernetes.py
@@ -32,7 +32,7 @@ class KubernetesBackend:
         )
         try:
             status = json.loads(a.read())["status"]["workflow"]
-        except:
+        except Exception:  # TODO: Specify Exception type
             return {"status": "UNKNOWN"}
 
         if status.get("succeeded") == 1:

--- a/src/recastatlas/backends/local.py
+++ b/src/recastatlas/backends/local.py
@@ -19,7 +19,7 @@ class LocalBackend:
 
         try:
             run_workflow(**spec)
-        except:
+        except Exception:  # TODO: Specify Exception type
             raise FailedRunException
 
     def run_packtivity(self, name, spec):
@@ -45,6 +45,6 @@ class LocalBackend:
                 ["docker", "info"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
             return rc == 0
-        except:
+        except Exception:  # TODO: Specify Exception type
             pass
         return False

--- a/src/recastatlas/backends/local.py
+++ b/src/recastatlas/backends/local.py
@@ -8,6 +8,7 @@ import os
 
 log = logging.getLogger(__name__)
 
+
 class LocalBackend:
     def run_workflow(self, name, spec):
         backend_config = config.backends['local']["fromstring"]

--- a/src/recastatlas/backends/reana.py
+++ b/src/recastatlas/backends/reana.py
@@ -1,3 +1,10 @@
+import contextlib
+import json
+import logging
+import os
+
+import urllib3
+import yadageschemas
 from reana_client.api.client import (
     get_workflow_status,
     ping,
@@ -5,17 +12,11 @@ from reana_client.api.client import (
     upload_to_server,
 )
 from reana_commons.api_client import get_current_api_client
-import os
-import yadageschemas
-import json
-import contextlib
-import urllib3
-from ..config import config
+
 from .. import exceptions
+from ..config import config
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-
-import logging
 
 log = logging.getLogger(__name__)
 

--- a/src/recastatlas/backends/reana.py
+++ b/src/recastatlas/backends/reana.py
@@ -109,5 +109,5 @@ class ReanaBackend:
             assert self.auth_token
             result = ping(self.auth_token)
             return not (result['error'])
-        except:
+        except Exception:  # TODO: Specify Exception type
             return False

--- a/src/recastatlas/config.py
+++ b/src/recastatlas/config.py
@@ -13,7 +13,7 @@ def conf_from_env(var, default=None):
     if v is not None:
         try:
             return yaml.safe_load(v)
-        except:
+        except Exception:  # TODO: Specify Exception type
             log.error(f'could not get config from env var {var} (value: {v})')
             raise
     return default

--- a/src/recastatlas/config.py
+++ b/src/recastatlas/config.py
@@ -7,7 +7,8 @@ import jsonschema
 
 log = logging.getLogger(__name__)
 
-def conf_from_env(var,default = None    ):
+
+def conf_from_env(var, default=None):
     v = os.environ.get(var)
     if v is not None:
         try:
@@ -16,15 +17,15 @@ def conf_from_env(var,default = None    ):
             log.error(f'could not get config from env var {var} (value: {v})')
             raise
     return default
-    
+
 
 class Config(object):
     @property
     def default_run_backend(self):
-        return os.environ.get('RECAST_DEFAULT_RUN_BACKEND','docker')
+        return os.environ.get('RECAST_DEFAULT_RUN_BACKEND', 'docker')
 
     def default_build_backend(self):
-        return os.environ.get('RECAST_DEFAULT_BUILD_BACKEND','docker')
+        return os.environ.get('RECAST_DEFAULT_BUILD_BACKEND', 'docker')
 
     @property
     def backends(self):
@@ -33,12 +34,18 @@ class Config(object):
                 "metadata": {
                     "short_description": "runs locally with natively installed tools"
                 },
-                "fromstring": conf_from_env("RECAST_LOCAL_BACKENDSTRING","multiproc:auto")
+                "fromstring": conf_from_env(
+                    "RECAST_LOCAL_BACKENDSTRING", "multiproc:auto"
+                ),
             },
             "docker": {
                 "metadata": {"short_description": "runs with containerized tools"},
-                "fromstring": conf_from_env("RECAST_DOCKER_BACKENDSTRING","multiproc:auto"),
-                "image": conf_from_env("RECAST_DOCKER_IMAGE", "recast/recastatlas:v0.1.7"),
+                "fromstring": conf_from_env(
+                    "RECAST_DOCKER_BACKENDSTRING", "multiproc:auto"
+                ),
+                "image": conf_from_env(
+                    "RECAST_DOCKER_IMAGE", "recast/recastatlas:v0.1.7"
+                ),
                 "cvmfs": {"location": "/cvmfs", "propagation": "rprivate"},
                 "reg": {
                     "user": conf_from_env("RECAST_REGISTRY_USERNAME"),
@@ -51,17 +58,25 @@ class Config(object):
             },
             "kubernetes": {
                 "metadata": {"short_description": "runs on a Kubernetes cluster"},
-                "buildkit_addr": conf_from_env("RECAST_KUBERNETES_BUILDKIT_ADDR",'kube-pod://buildkitd'),
+                "buildkit_addr": conf_from_env(
+                    "RECAST_KUBERNETES_BUILDKIT_ADDR", 'kube-pod://buildkitd'
+                ),
             },
             "reana": {
                 "metadata": {"short_description": "runs on a REANA deployment"},
-                "access_token": conf_from_env('REANA_ACCESS_TOKEN',None),
-                "cvmfs_repos": conf_from_env('RECAST_REANA_CVMFS_REPOS',['atlas.cern.ch','atlas-condb.cern.ch'])
-            }
+                "access_token": conf_from_env('REANA_ACCESS_TOKEN', None),
+                "cvmfs_repos": conf_from_env(
+                    'RECAST_REANA_CVMFS_REPOS', ['atlas.cern.ch', 'atlas-condb.cern.ch']
+                ),
+            },
         }
 
-    def catalogue_paths(self,include_default = True):
-        paths = [pkg_resources.resource_filename("recastatlas", "data/catalogue")] if include_default else []
+    def catalogue_paths(self, include_default=True):
+        paths = (
+            [pkg_resources.resource_filename("recastatlas", "data/catalogue")]
+            if include_default
+            else []
+        )
         configpath = os.environ.get("RECAST_ATLAS_CATALOGUE")
 
         if configpath:
@@ -73,46 +88,53 @@ class Config(object):
     def catalogue(self):
         cfg = {}
         files = []
-        files += [x for p in self.catalogue_paths() for x in glob.glob("{}/*.yml".format(p))]
+        files += [
+            x for p in self.catalogue_paths() for x in glob.glob("{}/*.yml".format(p))
+        ]
         files = list(set(files))
         log.debug(files)
         for f in files:
             log.debug(f'loading catalogue file {f}')
             entry = yaml.safe_load(open(f))
-            process_entry(cfg,f,entry)
+            process_entry(cfg, f, entry)
         return cfg
+
 
 config = Config()
 
-def process_entry(cfg,fname,entry,tags = None):
+
+def process_entry(cfg, fname, entry, tags=None):
     if (entry is not None) and is_entry_file(entry):
         name = entry.pop("name")
         if not "toplevel" in entry["spec"]:
             entry["spec"]["toplevel"] = os.path.realpath(
                 os.path.join(os.path.dirname(fname), "specs")
             )
-            entry['metadata'].setdefault('tags',[]).extend(tags or [])
+            entry['metadata'].setdefault('tags', []).extend(tags or [])
         cfg[name] = entry
     elif (entry is not None) and is_index_file(entry):
         for index_f in entry['recast_catalogue_entries']:
-            index_f = os.path.join(os.path.dirname(fname),index_f)
+            index_f = os.path.join(os.path.dirname(fname), index_f)
             log.debug(f'loading catalogue file {index_f}')
             index_entry = yaml.safe_load(open(index_f))
-            process_entry(cfg,index_f,index_entry,entry['tags'])
-            
+            process_entry(cfg, index_f, index_entry, entry['tags'])
+
+
 def is_entry_file(entry):
-    schema = jsonschema.Draft7Validator({'required': ['name','metadata','spec']})    
+    schema = jsonschema.Draft7Validator({'required': ['name', 'metadata', 'spec']})
     try:
         schema.validate(entry)
     except jsonschema.exceptions.ValidationError:
         return False
     return True
+
 
 def is_index_file(entry):
-    schema = jsonschema.Draft7Validator({'required': ['name','tags','recast_catalogue_entries']})    
+    schema = jsonschema.Draft7Validator(
+        {'required': ['name', 'tags', 'recast_catalogue_entries']}
+    )
     try:
         schema.validate(entry)
     except jsonschema.exceptions.ValidationError:
         return False
     return True
-

--- a/src/recastatlas/config.py
+++ b/src/recastatlas/config.py
@@ -106,7 +106,7 @@ config = Config()
 def process_entry(cfg, fname, entry, tags=None):
     if (entry is not None) and is_entry_file(entry):
         name = entry.pop("name")
-        if not "toplevel" in entry["spec"]:
+        if "toplevel" not in entry["spec"]:
             entry["spec"]["toplevel"] = os.path.realpath(
                 os.path.join(os.path.dirname(fname), "specs")
             )

--- a/src/recastatlas/exceptions.py
+++ b/src/recastatlas/exceptions.py
@@ -3,6 +3,7 @@ class FailedRunException(Exception):
     raised when an a run has not succeeded
     """
 
+
 class BackendNotAvailableException(Exception):
     """
     raise when a Backend is ill-configured

--- a/src/recastatlas/subcommands/auth.py
+++ b/src/recastatlas/subcommands/auth.py
@@ -24,11 +24,12 @@ def auth():
     pass
 
 
-@auth.command(help = "show current auth configuration")
+@auth.command(help="show current auth configuration")
 def show():
-    click.echo('Authdir: {}'.format(os.environ.get(envvar['auth_location'],'not set')))
+    click.echo('Authdir: {}'.format(os.environ.get(envvar['auth_location'], 'not set')))
 
-@auth.command(help = 'configure authentication')
+
+@auth.command(help='configure authentication')
 @click.option("-a", "--answer", multiple=True)
 def setup(answer):
     expt = "ATLAS"
@@ -111,9 +112,12 @@ def setup(answer):
     )
 
 
-
-@auth.command(help = 'Prepare auth data on-disk for steps requiring them')
-@click.option("--basedir", default=os.path.join(os.environ.get('HOME',os.getcwd()),'.recast','auth'), show_default=True)
+@auth.command(help='Prepare auth data on-disk for steps requiring them')
+@click.option(
+    "--basedir",
+    default=os.path.join(os.environ.get('HOME', os.getcwd()), '.recast', 'auth'),
+    show_default=True,
+)
 def write(basedir):
     if not os.path.exists(basedir):
         os.makedirs(basedir)
@@ -129,26 +133,42 @@ def write(basedir):
         "export {}={}".format(envvar["auth_location"], os.path.abspath(basedir))
     )
 
-    shutil.copy(pkg_resources.resource_filename("recastatlas", "data/getkrb_reana.sh"),os.path.join(basedir,"getkrb_reana.sh"))
-    shutil.copy(pkg_resources.resource_filename("recastatlas", "data/expect_script.sh"),os.path.join(basedir,"expect_script.sh"))
-    click.echo('Wrote Authentication Data to {} (Note! This includes passwords/tokens)'.format(basedir), err=True)
+    shutil.copy(
+        pkg_resources.resource_filename("recastatlas", "data/getkrb_reana.sh"),
+        os.path.join(basedir, "getkrb_reana.sh"),
+    )
+    shutil.copy(
+        pkg_resources.resource_filename("recastatlas", "data/expect_script.sh"),
+        os.path.join(basedir, "expect_script.sh"),
+    )
+    click.echo(
+        'Wrote Authentication Data to {} (Note! This includes passwords/tokens)'.format(
+            basedir
+        ),
+        err=True,
+    )
 
-@auth.command(help = 'Configure REANA with authentication information.')
+
+@auth.command(help='Configure REANA with authentication information.')
 def reana_setup():
-    click.secho((
-        "docker run --rm "+
-        "-v $PACKTIVITY_AUTH_LOCATION:$PACKTIVITY_AUTH_LOCATION -w $PACKTIVITY_AUTH_LOCATION "+
-        "reanahub/reana-auth-krb5:1.0.1 ./expect_script.sh $RECAST_AUTH_USERNAME $RECAST_AUTH_PASSWORD;"
-    ))
-    click.secho((
-        "reana-client secrets-add --overwrite "+
-        "--env CERN_USER=$RECAST_AUTH_USERNAME --env CERN_KEYTAB=reana_keytab "+
-        "--env KRB_SETUP_SCRIPT=/etc/reana/secrets/getkrb_reana.sh "+
-        "--file $PACKTIVITY_AUTH_LOCATION/getkrb_reana.sh --file $PACKTIVITY_AUTH_LOCATION/reana_keytab"
-    ))
+    click.secho(
+        (
+            "docker run --rm "
+            + "-v $PACKTIVITY_AUTH_LOCATION:$PACKTIVITY_AUTH_LOCATION -w $PACKTIVITY_AUTH_LOCATION "
+            + "reanahub/reana-auth-krb5:1.0.1 ./expect_script.sh $RECAST_AUTH_USERNAME $RECAST_AUTH_PASSWORD;"
+        )
+    )
+    click.secho(
+        (
+            "reana-client secrets-add --overwrite "
+            + "--env CERN_USER=$RECAST_AUTH_USERNAME --env CERN_KEYTAB=reana_keytab "
+            + "--env KRB_SETUP_SCRIPT=/etc/reana/secrets/getkrb_reana.sh "
+            + "--file $PACKTIVITY_AUTH_LOCATION/getkrb_reana.sh --file $PACKTIVITY_AUTH_LOCATION/reana_keytab"
+        )
+    )
 
 
-@auth.command(help = 'Unset/Remove auth-relevant env vars/directories')
+@auth.command(help='Unset/Remove auth-relevant env vars/directories')
 def destroy():
     if sys.stdout.isatty():
         click.secho("Use eval $(recast auth destroy) to unset the variables", fg="red")
@@ -161,10 +181,14 @@ def destroy():
             shutil.rmtree(auth_loc)
 
 
-@auth.command(help = 'check access for private images')
+@auth.command(help='check access for private images')
 @click.argument("image", default="gitlab-registry.cern.ch/lheinric/atlasonlytestimages")
-@click.option("--backend", type=click.Choice(["local", "docker"]), default=config.default_run_backend)
-def check_access_image(image,backend):
+@click.option(
+    "--backend",
+    type=click.Choice(["local", "docker"]),
+    default=config.default_run_backend,
+)
+def check_access_image(image, backend):
     if envvar["registry_user"] not in os.environ:
         raise RuntimeError("run `eval $(recast auth setup)` first")
 
@@ -218,14 +242,18 @@ environment:
     click.secho("Access: {}".format("ok" if log_ok else "not ok"))
 
 
-@auth.command(help = 'check access to private data')
+@auth.command(help='check access to private data')
 @click.option("--image", default="lukasheinrich/xrootdclient:latest")
 @click.argument(
     "location",
     default="root://eosuser.cern.ch//eos/project/r/recast/atlas/testauth/testfile.txt",
 )
-@click.option("--backend", type=click.Choice(["local", "docker"]), default=config.default_run_backend)
-def check_access_xrootd(image, location,backend):
+@click.option(
+    "--backend",
+    type=click.Choice(["local", "docker"]),
+    default=config.default_run_backend,
+)
+def check_access_xrootd(image, location, backend):
 
     image = image.split(":", 1)
     if len(image) > 1:
@@ -296,7 +324,7 @@ environment:
     click.secho("Access: {}".format("ok" if access_ok else "not ok"))
 
 
-@auth.command(help = 'configure to use preset on-disk loaction of auth data')
+@auth.command(help='configure to use preset on-disk loaction of auth data')
 @click.argument("location")
 def use(location):
     click.secho(

--- a/src/recastatlas/subcommands/catalogue.py
+++ b/src/recastatlas/subcommands/catalogue.py
@@ -131,7 +131,7 @@ toplevel     : {toplevel}
 @click.argument("example")
 def example(name, example):
     data = config.catalogue[name]
-    if not example in data.get("example_inputs", {}):
+    if example not in data.get("example_inputs", {}):
         click.secho("example not found.")
         return
     click.secho(yaml.dump(data["example_inputs"][example], default_flow_style=False))

--- a/src/recastatlas/subcommands/catalogue.py
+++ b/src/recastatlas/subcommands/catalogue.py
@@ -53,37 +53,41 @@ def create(name, path):
         )
     )
 
+
 @catalogue.command()
 def paths():
     paths = config.catalogue_paths()
-    out = '\n'.join(['* '+x for x in paths])
+    out = '\n'.join(['* ' + x for x in paths])
     click.secho('Paths considered by RECAST:\n--------------------------')
     click.secho(out)
+
 
 @catalogue.command()
 @click.argument("path")
 def add(path):
     path = os.path.realpath(path)
     if os.path.exists(path) and os.path.isdir(path):
-        paths = config.catalogue_paths(include_default = False)
+        paths = config.catalogue_paths(include_default=False)
         paths.append(path)
         paths = sorted(list(set(paths)))
         click.secho("export RECAST_ATLAS_CATALOGUE=" + ":".join(paths))
     else:
-        log.warning("path %s does not exist or is not a directory",path)
+        log.warning("path %s does not exist or is not a directory", path)
         raise click.Abort()
+
 
 @catalogue.command()
 @click.argument("path")
 def rm(path):
     path = os.path.realpath(path)
-    paths = config.catalogue_paths(include_default = False)
+    paths = config.catalogue_paths(include_default=False)
     filtered_paths = [p for p in paths if p != path]
     filtered_paths = sorted(list(set(filtered_paths)))
     if not filtered_paths:
         click.secho('unset RECAST_ATLAS_CATALOGUE')
     else:
         click.secho("export RECAST_ATLAS_CATALOGUE=" + ":".join(filtered_paths))
+
 
 @catalogue.command()
 def ls():
@@ -96,7 +100,7 @@ def ls():
                 k,
                 v.get("metadata", default_meta)["short_description"],
                 ",".join(list(v.get("example_inputs", {}).keys())),
-                ",".join(v.get("metadata", default_meta).get('tags',[]))
+                ",".join(v.get("metadata", default_meta).get('tags', [])),
             )
         )
 
@@ -114,7 +118,10 @@ description  : {short:20}
 author       : {author}
 toplevel     : {toplevel}
 """.format(
-        author=metadata.get("author",'N/A'), name=name, short=metadata.get("short_description","N/A"), toplevel = data['spec']['toplevel']
+        author=metadata.get("author", 'N/A'),
+        name=name,
+        short=metadata.get("short_description", "N/A"),
+        toplevel=data['spec']['toplevel'],
     )
     click.secho(toprint)
 

--- a/src/recastatlas/subcommands/run.py
+++ b/src/recastatlas/subcommands/run.py
@@ -42,7 +42,7 @@ def run(name, inputdata, example, backend, tag, format_result):
     else:
         try:
             inputs = data["example_inputs"][example]
-        except:
+        except Exception:  # TODO: Specify Exception type
             raise click.ClickException(
                 "Example '{}' not found. Choose from {}".format(
                     example, list(data.get("example_inputs", {}).keys())
@@ -54,7 +54,7 @@ def run(name, inputdata, example, backend, tag, format_result):
 
     try:
         run_sync(name, spec, backend=backend)
-    except:
+    except Exception:  # TODO: Specify Exception type
         log.exception("caught exception")
         exc = click.exceptions.ClickException(click.style("Workflow failed", fg="red"))
         exc.exit_code = 1
@@ -97,7 +97,7 @@ def submit(name, inputdata, example, infofile, tag, backend):
     else:
         try:
             inputs = data["example_inputs"][example]
-        except:
+        except Exception:  # TODO: Specify Exception type
             raise click.ClickException(
                 "Example '{}' not found. Choose from {}".format(
                     example, list(data.get("example_inputs", {}).keys())

--- a/src/recastatlas/subcommands/run.py
+++ b/src/recastatlas/subcommands/run.py
@@ -27,12 +27,16 @@ def make_spec(name, data, inputs):
 @click.argument("name")
 @click.argument("inputdata", default="")
 @click.option("--example", default="default")
-@click.option("--backend", type=click.Choice(["local", "docker"]), default=config.default_run_backend)
+@click.option(
+    "--backend",
+    type=click.Choice(["local", "docker"]),
+    default=config.default_run_backend,
+)
 @click.option("--tag", default=None)
 @click.option("--format-result/--raw", default=True)
 def run(name, inputdata, example, backend, tag, format_result):
     data = config.catalogue[name]
-            
+
     if inputdata:
         inputs = yaml.safe_load(open(inputdata))
     else:
@@ -49,15 +53,12 @@ def run(name, inputdata, example, backend, tag, format_result):
     spec = make_spec(instance_id, data, inputs)
 
     try:
-            run_sync(name, spec, backend=backend)
+        run_sync(name, spec, backend=backend)
     except:
         log.exception("caught exception")
-        exc = click.exceptions.ClickException(
-            click.style("Workflow failed", fg="red")
-        )
+        exc = click.exceptions.ClickException(click.style("Workflow failed", fg="red"))
         exc.exit_code = 1
         raise exc
-
 
     log.info("RECAST run finished.")
 
@@ -80,13 +81,14 @@ def run(name, inputdata, example, backend, tag, format_result):
             )
         )
 
+
 @click.command(help="Submit a RECAST Workflow asynchronously")
 @click.argument("name")
 @click.argument("inputdata", default="")
 @click.option("--example", default="default")
 @click.option("--infofile", default=None)
 @click.option("--tag", default=None)
-@click.option("--backend", type = click.Choice(['kubernetes','reana']))
+@click.option("--backend", type=click.Choice(['kubernetes', 'reana']))
 def submit(name, inputdata, example, infofile, tag, backend):
     analysis_id = name
     data = config.catalogue[analysis_id]
@@ -110,16 +112,25 @@ def submit(name, inputdata, example, infofile, tag, backend):
     click.secho("{} submitted".format(str(instance_id)))
     if infofile:
         with open(infofile, "w") as info:
-            json.dump({"analysis_id": analysis_id, "instance_id": instance_id, 'submission': submission}, info)
+            json.dump(
+                {
+                    "analysis_id": analysis_id,
+                    "instance_id": instance_id,
+                    'submission': submission,
+                },
+                info,
+            )
+
 
 @click.command(help="Get the Status of a asynchronous submission")
 @click.option("--infofile", default=None)
-@click.option("--backend", type = click.Choice(['kubernetes','reana']))
+@click.option("--backend", type=click.Choice(['kubernetes', 'reana']))
 def status(infofile, backend):
     submission = json.load(open(infofile))
     instance = submission['instance_id']
     status = check_async(submission, backend=backend)
     click.secho("{}\t{}".format(instance, status["status"]))
+
 
 @click.command(help="Retrieve RECAST Results from asynchronous submissions")
 @click.option("--name", default=None)

--- a/src/recastatlas/subcommands/run.py
+++ b/src/recastatlas/subcommands/run.py
@@ -62,7 +62,7 @@ def run(name, inputdata, example, backend, tag, format_result):
 
     log.info("RECAST run finished.")
 
-    if not "results" in data:
+    if "results" not in data:
         log.info(
             "No result file specified in config. Check out workdir for {} manually".format(
                 instance_id
@@ -166,7 +166,7 @@ def retrieve(infofile, name, instance, show_url, tunnel, format_result):
         )
         return
     data = config.catalogue[name]
-    if not "results" in data:
+    if "results" not in data:
         log.info(
             "No result file specified in config. Check out workdir for {} manually".format(
                 name

--- a/src/recastatlas/subcommands/software.py
+++ b/src/recastatlas/subcommands/software.py
@@ -4,7 +4,7 @@ import os
 from ..config import config
 
 
-@click.group(help = 'Build Container Images for RECAST')
+@click.group(help='Build Container Images for RECAST')
 def software():
     pass
 
@@ -12,10 +12,14 @@ def software():
 @software.command()
 @click.argument('name')
 @click.argument('path', default='.')
-@click.option('--backend', type=click.Choice(['docker', 'kubernetes']), default = config.default_build_backend)
+@click.option(
+    '--backend',
+    type=click.Choice(['docker', 'kubernetes']),
+    default=config.default_build_backend,
+)
 @click.option('--addr', default=config.backends['kubernetes']['buildkit_addr'])
 @click.option('--push/--no-push', default=False)
-def build(path, name, backend, addr,push):
+def build(path, name, backend, addr, push):
     image = 'gitlab-registry.cern.ch/recast-atlas/images/{}'.format(name)
     path = os.path.abspath(path)
     if backend == 'kubernetes':
@@ -32,7 +36,7 @@ def build(path, name, backend, addr,push):
                 '--local',
                 'dockerfile={}'.format(path),
                 '--output',
-                'type=image,name={},push={}'.format(image,'true' if push else 'false'),
+                'type=image,name={},push={}'.format(image, 'true' if push else 'false'),
             ]
         )
     elif backend == 'docker':

--- a/src/recastatlas/subcommands/testing.py
+++ b/src/recastatlas/subcommands/testing.py
@@ -41,7 +41,7 @@ def run(name, testname, backend, tag):
     data = config.catalogue[name]
     testdict = {t.pop("name"): t for t in data["tests"]}
     for k, v in testdict.items():
-        if not "toplevel" in v:
+        if "toplevel" not in v:
             v["toplevel"] = data["spec"]["toplevel"]
 
     instance_id = "recast-test-{}".format(tag or str(uuid.uuid1()).split("-")[0])
@@ -67,7 +67,7 @@ def shell(name, testname, backend, tag):
     data = config.catalogue[name]
     testdict = {t.pop("name"): t for t in data["tests"]}
     for k, v in testdict.items():
-        if not "toplevel" in v:
+        if "toplevel" not in v:
             v["toplevel"] = data["spec"]["toplevel"]
 
     instance_id = "recast-testshell-{}".format(tag or str(uuid.uuid1()).split("-")[0])

--- a/src/recastatlas/subcommands/testing.py
+++ b/src/recastatlas/subcommands/testing.py
@@ -31,7 +31,11 @@ def ls(name):
 @testing.command(help="Run a test")
 @click.argument("name")
 @click.argument("testname")
-@click.option("--backend", type=click.Choice(["local", "docker"]), default = config.default_run_backend)
+@click.option(
+    "--backend",
+    type=click.Choice(["local", "docker"]),
+    default=config.default_run_backend,
+)
 @click.option("--tag", default=None)
 def run(name, testname, backend, tag):
     data = config.catalogue[name]
@@ -53,7 +57,11 @@ def run(name, testname, backend, tag):
 @testing.command(help="Run a test")
 @click.argument("name")
 @click.argument("testname")
-@click.option("--backend", type=click.Choice(["local", "docker"]), default=config.default_run_backend)
+@click.option(
+    "--backend",
+    type=click.Choice(["local", "docker"]),
+    default=config.default_run_backend,
+)
 @click.option("--tag", default=None)
 def shell(name, testname, backend, tag):
     data = config.catalogue[name]

--- a/src/recastatlas/testing.py
+++ b/src/recastatlas/testing.py
@@ -24,7 +24,7 @@ def validate_entry(data):
             },
         )
         return True
-    except:
+    except Exception:  # TODO: Specify Exception type
         pass
     return False
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,15 +4,19 @@ from recastatlas.subcommands.run import run
 from recastatlas.subcommands.catalogue import catalogue
 import os
 
+
 def test_cli():
     runner = CliRunner()
     test = runner.invoke(recastatlas)
     assert test.exit_code == 0
 
+
 def test_run_hello_world(tmpdir):
     with tmpdir.as_cwd():
         runner = CliRunner()
-        test = runner.invoke(run,['testing/busyboxtest','--backend','local','--tag','hello'])
+        test = runner.invoke(
+            run, ['testing/busyboxtest', '--backend', 'local', '--tag', 'hello']
+        )
         assert test.exit_code == 0
         assert os.path.exists('recast-hello')
         assert os.path.exists('recast-hello/world/world.txt')
@@ -20,5 +24,5 @@ def test_run_hello_world(tmpdir):
 
 def test_run_catalogue():
     runner = CliRunner()
-    test = runner.invoke(catalogue,['ls'])
+    test = runner.invoke(catalogue, ['ls'])
     assert test.exit_code == 0


### PR DESCRIPTION
Requires PR #43 to go in first.

---

Apply linting with Black and flake8 such that the Lint CI workflow passes.

```
* Use flake8 over pyflakes
   - Add .flake8 to configure flake8
* Apply Black to codebase
* Fix flake8 errors and warnings
   - E402: module level import not at top of file
   - E713: test for membership should be 'not in'
   - E722: do not use bare 'except'
   - W291: trailing whitespace
```