### PR TITLE
ci: Fix Docker build workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,3 +78,9 @@ jobs:
 
       - name: List built images
         run: docker images
+
+      - name: Check recast CLI functional
+        run: >-
+          docker run --rm
+          recast/recastatlas:sha-${GITHUB_SHA::8}
+          sh -c 'recast --help'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,9 +78,3 @@ jobs:
 
       - name: List built images
         run: docker images
-
-      - name: Check basic run works
-        run: >-
-          docker run --rm
-          recast/recastatlas:sha-${GITHUB_SHA::8}
-          -c "recast --help; recast run testing/busyboxtest --backend local"


### PR DESCRIPTION
Fix the Docker build CI

~~To run `recast run testing/busyboxtest --backend docker` ensure that the environmental variable `RECASE_DOCKER_IMAGE` is set to the value of the image that was just build in CI. Additionally, running recast locally requires that it is both installed and that `graphviz` is installed too.~~

To run `recast run testing/busyboxtest --backend docker` in GitHub Actions CI requires some additional work to get the Docker in Docker setup. For the time being, be content with the build tests of the Dockerfile and local testing elsewhere.

c.f. Issue #50

The equivalent to running

```console
recast run testing/busyboxtest --backend local
```

is still being run in 

https://github.com/recast-hep/recast-atlas/blob/4eba02ea6678f253a9bb578cf70385d01b581f32/.github/workflows/ci.yml#L44-L46