### PR TITLE
build: Migrate setup spec and metadata from `setup.py` to `setup.cfg`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,6 +3,6 @@ current_version = 0.1.7
 commit = True
 tag = True
 
-[bumpversion:file:setup.py]
+[bumpversion:file:setup.cfg]
 
 [bumpversion:file:src/recastatlas/config.py]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,48 @@
+[metadata]
+name = recast-atlas
+version = 0.1.7
+description = RECAST for ATLAS at the LHC
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/recast-hep/recast-atlas
+author = Lukas Heinrich
+author_email = lukas.heinrich@cern.ch
+license = Apache
+license_file = LICENSE
+keywords = physics recast atlas
+project_urls =
+    Documentation = https://github.com/recast-hep/recast-atlas
+    Source Code = https://github.com/recast-hep/recast-atlas
+    Issue Tracker = https://github.com/recast-hep/recast-atlas/issues
+classifiers =
+    Development Status :: 4 - Beta
+    License :: OSI Approved :: Apache Software License
+    Intended Audience :: Science/Research
+    Topic :: Scientific/Engineering
+    Topic :: Scientific/Engineering :: Physics
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: Implementation :: CPython
+
+[options]
+package_dir =
+    = src
+packages = find:
+include_package_data = True
+python_requires = >=3.6
+# TODO: Empirically evaluate lower bounds
+install_requires =
+    click>=7.0  # for console scripts
+    jsonschema>=3.0.0
+    pyyaml>=5.1  # for parsing CLI options
+    yadage-schemas==0.10.6  # lock to yadage
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+console_scripts =
+    recast = recastatlas.cli:recastatlas

--- a/setup.py
+++ b/setup.py
@@ -1,47 +1,18 @@
-from setuptools import setup, find_packages
-from os import path
-import sys
+from setuptools import setup
 
-this_directory = path.abspath(path.dirname(__file__))
-if sys.version_info.major < 3:
-    from io import open
-with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md:
-    long_description = readme_md.read()
-
-setup(
-    name='recast-atlas',
-    version='0.1.7',
-    description='RECAST for ATLAS at the LHC',
-    url='',
-    author='Lukas Heinrich',
-    author_email='lukas.heinrich@cern.ch',
-    package_dir={'': 'src'},
-    packages=find_packages(where='src'),
-    include_package_data=True,
-    install_requires=[
-        'click',
-        'jsonschema',
-        'pyyaml',
+extras_require = {
+    'develop': {'pytest', 'flake8>=3.9.0', 'black'},
+    'local': [
+        'pydotplus==2.0.2',
+        'adage==0.10.1',
         'yadage-schemas==0.10.6',
+        'packtivity==0.14.23',
+        'yadage==0.20.1',  # yadage[viz] breaks so install following manually
+        'pydot',  # from yadage[viz] extra
+        'pygraphviz',  # from yadage[viz] extra
     ],
-    extras_require={
-        'develop': {'pytest', 'flake8>=3.9.0', 'black'},
-        'local': [
-            'pydotplus==2.0.2',
-            'adage==0.10.1',
-            'yadage-schemas==0.10.6',
-            'packtivity==0.14.23',
-            'yadage==0.20.1',  # yadage[viz] breaks so install following manually
-            'pydot',  # from yadage[viz] extra
-            'pygraphviz',  # from yadage[viz] extra
-        ],
-        'kubernetes': ['kubernetes==9.0.0'],
-        'reana': ['reana-client==0.7.5'],
-    },
-    entry_points={
-        'console_scripts': [
-            'recast=recastatlas.cli:recastatlas',
-        ],
-    },
-    dependency_links=[],
-)
+    'kubernetes': ['kubernetes==9.0.0'],
+    'reana': ['reana-client==0.7.5'],
+}
+
+setup(extras_require=extras_require)


### PR DESCRIPTION
Resolves #40

Requires PR #46 to go in first

```
* Migrate all PyPI metadata and declarative setup information to setup.cfg
* Have bumpversion update version information in setup.cfg
* Add requirement of Python 3.6 or later for install
* Set approximate lower bounds on recast-atlas core dependencies
* Add PyPI classifier metadata and project urls
```