### PR TITLE
build: Require setuptools<58.0.0 for reana extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ extras_require = {
         'pygraphviz',  # from yadage[viz] extra
     ],
     'kubernetes': ['kubernetes==9.0.0'],
-    'reana': ['reana-client==0.7.5'],
+    'reana': [
+        'setuptools<58.0.0',  # c.f. https://github.com/reanahub/reana-client/issues/558
+        'reana-client==0.7.5',
+    ],
 }
 
 setup(extras_require=extras_require)


### PR DESCRIPTION
Requires PR #46 to go in first.

---

`reana-client` `v0.7.5` has a dependency on `cwltool==1.0.20191022103248` which apparently has conflicts with `setuptools` `v58.0.0` and later, presumably from the [breaking changes](https://github.com/pypa/setuptools/blob/main/CHANGES.rst#breaking-changes) that were introduced of

> Removed support for 2to3 during builds. Projects should port to a unified codebase or pin to an older version of Setuptools using PEP 518 build-requires.

The release of `reana-client` `v0.8.0` will fix this and the `setuptools` restriction will be able to be removed.

c.f. reanahub/reana-client#558