### PR TITLE
build: Revise MANIFEST.in strategy to properly use prune

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,12 @@
-recursive-include src/recastatlas/data *
+prune **
+graft src
+graft tests
+
+include setup.py
+include setup.cfg
+include LICENSE
+include README.md
+include pyproject.toml
+include MANIFEST.in
+
+global-exclude __pycache__ *.py[cod]


### PR DESCRIPTION
Applies https://github.com/scikit-hep/pyhf/pull/1449

```
* Use `prune **` to remove all files from the sdist
   - c.f. https://packaging.python.org/guides/using-manifest-in/#manifest-in-commands
   - "Setuptools also has undocumented support for ** matching zero or more characters including forward slash, backslash, and colon."
* Manually include all "default" files for a sdist in MANIFEST.in
   - c.f. https://packaging.python.org/guides/using-manifest-in/#how-files-are-included-in-an-sdist
```