### PR TITLE
ci: Add workflow to deploy to distributions to TestPyPI and PyPI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,26 +2,18 @@ name: Deploy
 
 on:
   create:
-    tags:        
+    tags:
       - .*
 
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@master
-    - name: Create Python Dist
-      run: |
-        python setup.py sdist
-      
-    - name: Upload to PyPI
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USER }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASS }}
-      run: |
-        python -m pip install twine
-        python -m twine upload dist/*
+
+    - name: Checkout
+      uses: actions/checkout@v2
 
     - name: Docker Build
       env:
@@ -35,4 +27,4 @@ jobs:
         DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
       run: |
         docker login -u $DOCKERHUB_USER -p $DOCKERHUB_PASS
-        docker push recast/recastatlas:${GITHUB_REF:10}        
+        docker push recast/recastatlas:${GITHUB_REF:10}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
 name: Deploy
 
 on:
-  create:
+  push:
     tags:
-      - .*
+      - v*
 
 jobs:
   deploy:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -2,8 +2,10 @@ name: publish distributions
 
 on:
   push:
-    # branches:
-    # - master
+    branches:
+    - master
+    tags:
+      - v*
   pull_request:
     branches:
     - master
@@ -52,14 +54,15 @@ jobs:
       run: python -m zipfile --list dist/recast_atlas-*.whl
 
     - name: Publish distribution 📦 to Test PyPI
-      # every PR will trigger a push event on master, so check the push event is actually coming from master
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'recast-hep/recast-atlas'
+      # publish to TestPyPI on tag events
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'recast-hep/recast-atlas'
       uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish distribution 📦 to PyPI
+      # publish to PyPI on releases
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'recast-hep/recast-atlas'
       uses: pypa/gh-action-pypi-publish@v1.4.2
       with:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -2,8 +2,8 @@ name: publish distributions
 
 on:
   push:
-    branches:
-    - master
+    # branches:
+    # - master
   pull_request:
     branches:
     - master

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,66 @@
+name: publish distributions
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    name: Build and publish Python distro to (Test)PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install build, check-manifest, and twine
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install build check-manifest twine
+        python -m pip list
+
+    - name: Check MANIFEST
+      run: |
+        check-manifest
+
+    - name: Build a sdist and a wheel
+      run: |
+        python -m build --outdir dist/ .
+
+    - name: Verify the distribution
+      run: twine check dist/*
+
+    - name: List contents of sdist
+      run: python -m tarfile --list dist/recast-atlas-*.tar.gz
+
+    - name: List contents of wheel
+      run: python -m zipfile --list dist/recast_atlas-*.whl
+
+    - name: Publish distribution 📦 to Test PyPI
+      # every PR will trigger a push event on master, so check the push event is actually coming from master
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'recast-hep/recast-atlas'
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish distribution 📦 to PyPI
+      if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'recast-hep/recast-atlas'
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Add GHA based workflow to release a sdist and wheel to:
- TestPyPI on tags
- PyPI on GitHub releases

Locally on `master` run:

```console
$ git checkout master && git pull # verify that you're on master and synced with GitHub
$ bump2version <part> # bump the version and create a commit and tag
$ git push origin master --tags # push the commit and the tag to GitHub, causing TestPyPI to publish
```

- Got to TestPyPI (https://test.pypi.org/project/recast-atlas/) to look if the release looks okay
- Then on GitHub:
   1. Go to releases: https://github.com/recast-hep/recast-atlas/releases
   2. Click "Draft a new release"
   3. On the new page enter the tag you just pushed (e.g. `v0.1.0`) in the "Tag version" box and the "Release title" box (to make it easy unless you really want to get descriptive)
   4. Enter any release notes and click "Publish release"
- This then kicks of the publication CD workflow that will use the PyPI API key to publish.

```
* Publish sdists and wheels to TestPyPI through pushed tags triggered through push events
* Publish sdists and wheels to PyPI through published release events triggered through GitHub releases
   - c.f. https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#release
* Remove publishing setup on deploy.yml workflow
```