### PR TITLE
docs: Include push of commit in release workflow instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![CI](https://github.com/recast-hep/recast-atlas/actions/workflows/ci.yml/badge.svg)](https://github.com/recast-hep/recast-atlas/actions/workflows/ci.yml?query=branch%3Amaster)
 [![PyPI version](https://badge.fury.io/py/recast-atlas.svg)](https://badge.fury.io/py/recast-atlas)
 
-ATLAS tools to facilitate integration of ATLAS anlayses into RECAST
+ATLAS tools to facilitate integration of ATLAS analyses into RECAST
 
-## Gettting Started
+## Getting Started
 
 ### Install
 
@@ -17,7 +17,7 @@ python -m pip install recast-atlas
 
 ### Running RECAST
 
-The `recast` tool aims to enable both local execution as well as asynchronous execution on  a [REANA](http://reana.io) cluster. Via the 
+The `recast` tool aims to enable both local execution as well as asynchronous execution on a [REANA](http://reana.io) cluster. Via the
 
 #### Locally:
 

--- a/docs/maintainer-notes.md
+++ b/docs/maintainer-notes.md
@@ -19,7 +19,7 @@ $ bump2version <part>
 3. Push the commit and the tag to GitHub, triggering a distribution to be built and published to [TestPyPI](https://test.pypi.org/project/recast-atlas/).
 
 ```console
-$ git push --tags
+$ git push origin master --tags
 ```
 
 4. Got to [TestPyPI](https://test.pypi.org/project/recast-atlas/) to check that the release page looks okay. If you want to verify that the sdist and wheel are valid you can either download them manually or with


### PR DESCRIPTION
Amends PR #61 

It turns out that

https://github.com/recast-hep/recast-atlas/blob/7bb98286e2bddce46c18afa88eee88a53e6f4998/docs/maintainer-notes.md#L21-L23

isn't quite enough as that will only push the new tag with no commit. To push both the commit and the tag at the same time use


```console
git push origin <default branch name> --tags
```

```
* Include commit information to push with tags when triggering deployment to TestPyPI
* Fix typos in README
```