### PR TITLE
ci: Add Kubernetes and REANA dependencies to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install --no-cache-dir .[develop,local]
+        python -m pip --quiet install --no-cache-dir .[develop,local,kubernetes,reana]
         python -m pip list
 
     - name: Run unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        # RE: setuptools c.f. https://github.com/reanahub/reana-client/issues/558
+        python -m pip install --upgrade pip "setuptools<58.0.0" wheel
         python -m pip --quiet install --no-cache-dir .[develop,local,kubernetes,reana]
         python -m pip list
 


### PR DESCRIPTION
Run the CI with the Kubernetes and REANA dependencies additionally installed to determine the behavior in a "full" environment. This requires that `setuptools<58.0.0` given https://github.com/reanahub/reana-client/issues/558 and there is not a `v0.8.0` `reana-client` release yet.

```
* Install 'kubernetes' and 'reana' extras in CI before running tests
* Restrict setuptools<58.0.0 to allow for installation of reana-client
   - c.f. https://github.com/reanahub/reana-client/issues/558
```