### PR TITLE
fix: Add ttf-freefont to Dockerfile for graphviz

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,8 @@ RUN  apk add py-pip automake autoconf libtool \
              python3 python3-dev musl-dev libffi-dev tree \
              python3-dev musl-dev libffi-dev gcc \
              autoconf curl gcc ipset ipset-dev iptables iptables-dev libnfnetlink libnfnetlink-dev libnl3 libnl3-dev make musl-dev openssl openssl-dev \
-             jq util-linux font-bitstream-type1 build-base graphviz-dev imagemagick graphviz gcc musl-dev python3-dev libffi-dev openssl-dev cargo libxml2-dev libxslt-dev
+             jq util-linux font-bitstream-type1 build-base graphviz-dev imagemagick graphviz gcc musl-dev python3-dev libffi-dev openssl-dev cargo libxml2-dev libxslt-dev \
+             ttf-freefont
 WORKDIR /code
 COPY . /code
 RUN pip3 install lxml cryptography jq
@@ -12,4 +13,3 @@ ENV PACKTIVITY_DOCKER_CMD_MOD "-u root"
 ENV PACKTIVITY_CVMFS_LOCATION /shared-mounts/cvmfs
 ENV PACKTIVITY_CVMFS_PROPAGATION rslave
 WORKDIR /work
-


### PR DESCRIPTION
Resolves #67

`ttf-freefont` is necessary for graph label text to get rendered on the DAGs that `graphviz` draws when the `dot` command is run

```
* Add ttf-freefont to Dockerfile installs
   - Necessary font dependency of graphviz
```