### PR TITLE
chore: Remove duplicate apk entries in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM docker:20.10.5
-RUN apk add \
+
+RUN apk add --update && \
+    apk add --no-cache \
         build-base \
         gcc \
         make \


### PR DESCRIPTION
```
* Remove duplicate apk entries in Dockerfile
* Run `apk add --update` first and run `apk add` with `--no-cache` option
* Split apk entries out across lines for easier versioning
```