### PR TITLE
chore: Reduce Python installs to one Docker layer

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,10 @@ COPY . /code
 
 # c.f. https://github.com/reanahub/reana-client/issues/558
 RUN python3 -m pip --no-cache-dir install --upgrade pip 'setuptools<58.0.0' wheel && \
-    python3 -m pip --no-cache-dir install lxml cryptography jq && \
+    python3 -m pip --no-cache-dir install \
+        lxml \
+        cryptography \
+        jq && \
     python3 -m pip --no-cache-dir install .[local,kubernetes,reana]
 
 ENV PACKTIVITY_DOCKER_CMD_MOD "-u root"


### PR DESCRIPTION
```
* Combine all RUN commands that involve installing Python packages
to reduce them to one Docker layer
* Use --no-cache-dir to reduce size
* Remove editable install of recast-atlas as editable feature not used
at runtime
* Upgrade pip, setuptools, and wheel before other installs
   - Require setuptools<58.0.0
   - c.f. https://github.com/reanahub/reana-client/issues/558
```