### PR TITLE
fix: Add six to install requirements for yadage-schemas

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     jsonschema>=3.0.0
     pyyaml>=5.1  # for parsing CLI options
     yadage-schemas==0.10.6  # lock to yadage
+    six>=1.4.0  #  c.f. https://github.com/yadage/yadage-schemas/issues/35
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Resolves #76

`yadage-schemas` currently (`v0.10.6`) fails to specify its requirement on `six` `v1.4.0+` in its install_requires. c.f. https://github.com/yadage/yadage-schemas/issues/35

To safeguard against this, temporarily add `six>=1.4.0` to `install_requires` in `setup.cfg`.