### PR TITLE
feat: Report 'NOT AVAILABLE' if backend unloaded

### DIFF
--- a/src/recastatlas/backends/__init__.py
+++ b/src/recastatlas/backends/__init__.py
@@ -5,6 +5,7 @@ import os
 import textwrap
 import shlex
 from .. import exceptions
+from recastatlas.exceptions import BackendNotAvailableException
 
 log = logging.getLogger(__name__)
 
@@ -87,7 +88,10 @@ def check_async(name, backend):
 
 
 def check_backend(backend):
-    return BACKENDS[backend].check_backend()
+    try:
+        return BACKENDS[backend].check_backend()
+    except KeyError:
+        raise BackendNotAvailableException
 
 
 def install_backend(backend):

--- a/src/recastatlas/subcommands/backends.py
+++ b/src/recastatlas/subcommands/backends.py
@@ -1,6 +1,7 @@
 import click
 from ..config import config
 from ..backends import check_backend
+from recastatlas.exceptions import BackendNotAvailableException
 
 
 @click.group(help="The RECAST computational backends.")
@@ -13,12 +14,22 @@ def backends():
 def ls(check):
     fmt = "{0:20}{1:60}{2:10}"
     click.secho(fmt.format("NAME", "DESCRIPTION", "STATUS"))
-    for k, v in config.backends.items():
+    for backend, conf in config.backends.items():
         if check:
-            status = "OK" if check_backend(k) else "NOT OK"
+            try:
+                status = "OK" if check_backend(backend) else "NOT OK"
+            except BackendNotAvailableException:
+                # check_backend is performed by iterating through the global
+                # dict recastatlas.backends.BACKENDS and checking each backend
+                # key. If a backend is missing from the installation it will
+                # not be loaded into the dict and will raise a
+                # recastatlas.exceptions.BackendNotAvailableException.
+                status = "NOT AVAILABLE"
         else:
             status = ""
         default = {"short_description": "no description given"}
         click.secho(
-            fmt.format(k, v.get("metadata", default)["short_description"], status)
+            fmt.format(
+                backend, conf.get("metadata", default)["short_description"], status
+            )
         )


### PR DESCRIPTION
Resolves #75

If a backend is unloadable during `recast backends ls --check`, instead of raising a `KeyError`, instead catch the `KeyError`, raise `recastatlas.exceptions.BackendNotAvailableException`, and report 'NOT AVAILABLE' for the STATUS.

**Example:**
```console
$ docker run --rm -it python:3.8 /bin/bash
root@d6fcd8105311:/# python -m venv venv && . venv/bin/activate
(venv) root@d6fcd8105311:/# python -m pip --quiet install --upgrade pip "setuptools<58.0.0" wheel six
(venv) root@d6fcd8105311:/# git clone https://github.com/recast-hep/recast-atlas.git && cd recast-atlas && git checkout origin/feat/note-module-misisng-over-fail -b feat/note-module-misisng-over-fail
(venv) root@d6fcd8105311:/recast-atlas# python -m pip install .
(venv) root@d6fcd8105311:/recast-atlas# recast backends ls --check
NAME                DESCRIPTION                                                 STATUS    
local               runs locally with natively installed tools                  NOT AVAILABLE
docker              runs with containerized tools                               NOT OK    
kubernetes          runs on a Kubernetes cluster                                NOT OK    
reana               runs on a REANA deployment                                  NOT AVAILABLE
(venv) root@d6fcd8105311:/recast-atlas# apt update -y && apt install -y graphviz graphviz-dev
(venv) root@d6fcd8105311:/recast-atlas# python -m pip install .[local,reana]
(venv) root@d6fcd8105311:/recast-atlas# recast backends ls --check
NAME                DESCRIPTION                                                 STATUS    
local               runs locally with natively installed tools                  NOT OK    
docker              runs with containerized tools                               NOT OK    
kubernetes          runs on a Kubernetes cluster                                NOT OK    
reana               runs on a REANA deployment                                  NOT AVAILABLE
```

In the example above this is hitting the `recastatlas.exceptions.BackendNotAvailableException: no REANA auth found` from

https://github.com/recast-hep/recast-atlas/blob/63d06a76fc231df7ce6af30c87db89e14cb5840c/src/recastatlas/backends/__init__.py#L11-L17

as the modules exist

```
(venv) root@d6fcd8105311:/recast-atlas# pip list | grep reana
reana-client           0.7.5
reana-commons          0.7.5
```