### PR TITLE
fix: Login to docker registry with `--password-stdin` to avoid warning

### DIFF
--- a/src/recastatlas/subcommands/auth.py
+++ b/src/recastatlas/subcommands/auth.py
@@ -100,9 +100,8 @@ def setup(answer):
     click.secho(f"export {envvar['registry_user']}='{username}'")
     click.secho(f"export {envvar['registry_pass']}='{token}'")
     click.secho(
-        "docker login -u ${} -p ${} ${}".format(
-            envvar["registry_user"], envvar["registry_pass"], envvar["registry_host"]
-        )
+        f"printf \"${{{envvar['registry_pass']}}}\" | "
+        + f"docker login --username \"${{{envvar['registry_user']}}}\" --password-stdin \"${{{envvar['registry_host']}}}\""
     )
     click.secho(
         "You password is stored in the environment variables {}. Run `eval $(recast auth destroy)` to clear your password or exit the shell.".format(

--- a/src/recastatlas/subcommands/auth.py
+++ b/src/recastatlas/subcommands/auth.py
@@ -92,13 +92,13 @@ def setup(answer):
     token = answers["token"]
     registry = answers["registry"]
 
-    click.secho("export {}='{}'".format(envvar["auth_user"], username))
-    click.secho("export {}='{}'".format(envvar["auth_pass"], password))
-    click.secho("export {}='{}'".format(envvar["spec_load"], token))
-    click.secho("export {}='{}'".format(envvar["init_load"], token))
-    click.secho("export {}='{}'".format(envvar["registry_host"], registry))
-    click.secho("export {}='{}'".format(envvar["registry_user"], username))
-    click.secho("export {}='{}'".format(envvar["registry_pass"], token))
+    click.secho(f"export {envvar['auth_user']}='{username}'")
+    click.secho(f"export {envvar['auth_pass']}='{password}'")
+    click.secho(f"export {envvar['spec_load']}='{token}'")
+    click.secho(f"export {envvar['init_load']}='{token}'")
+    click.secho(f"export {envvar['registry_host']}='{registry}'")
+    click.secho(f"export {envvar['registry_user']}='{username}'")
+    click.secho(f"export {envvar['registry_pass']}='{token}'")
     click.secho(
         "docker login -u ${} -p ${} ${}".format(
             envvar["registry_user"], envvar["registry_pass"], envvar["registry_host"]

--- a/src/recastatlas/subcommands/auth.py
+++ b/src/recastatlas/subcommands/auth.py
@@ -104,9 +104,8 @@ def setup(answer):
         + f"docker login --username \"${{{envvar['registry_user']}}}\" --password-stdin \"${{{envvar['registry_host']}}}\""
     )
     click.secho(
-        "You password is stored in the environment variables {}. Run `eval $(recast auth destroy)` to clear your password or exit the shell.".format(
-            ",".join(envvar.values())
-        ),
+        f"NOTE! Your password and private information are stored in the environmental variables:\n{','.join(envvar.values())}\n"
+        + "Run `eval $(recast auth destroy)` to unset these environmental variables or exit the shell.\n",
         err=True,
     )
 


### PR DESCRIPTION
Attempting to login to a Docker registry using `docker login -p` will generate the warning message from Docker

```
WARNING! Using --password via the CLI is insecure. Use --password-stdin
```

to avoid this use `printf` and pipes to send the user password to docker login resulting in the command

```
printf "${RECAST_REGISTRY_PASSWORD}" | docker login --username "${RECAST_REGISTRY_USERNAME}" --password-stdin "${RECAST_REGISTRY_HOST}"
```

being used by `recast auth setup`. Additionally use f-strings to simplify formatting and update the warning message users see RE: environmental variables.

## recast-atlas `v0.1.8`

```bash
eval "$(recast auth setup -a ${RECAST_AUTH_USERNAME} -a ${RECAST_AUTH_PASSWORD} -a ${RECAST_AUTH_TOKEN} -a default)"
```
```
You password is stored in the environment variables RECAST_AUTH_USERNAME,RECAST_AUTH_PASSWORD,YADAGE_SCHEMA_LOAD_TOKEN,YADAGE_INIT_TOKEN,RECAST_REGISTRY_USERNAME,RECAST_REGISTRY_PASSWORD,RECAST_REGISTRY_HOST,PACKTIVITY_AUTH_LOCATION. Run `eval $(recast auth destroy)` to clear your password or exit the shell.
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
WARNING! Your password will be stored unencrypted in /home/feickert/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
```

## This PR

```bash
eval "$(recast auth setup -a ${RECAST_AUTH_USERNAME} -a ${RECAST_AUTH_PASSWORD} -a ${RECAST_AUTH_TOKEN} -a default)"
```
```
NOTE! Your password and private information are stored in the environmental variables:
RECAST_AUTH_USERNAME,RECAST_AUTH_PASSWORD,YADAGE_SCHEMA_LOAD_TOKEN,YADAGE_INIT_TOKEN,RECAST_REGISTRY_USERNAME,RECAST_REGISTRY_PASSWORD,RECAST_REGISTRY_HOST,PACKTIVITY_AUTH_LOCATION
Run `eval $(recast auth destroy)` to unset these environmental variables or exit the shell.

WARNING! Your password will be stored unencrypted in /home/feickert/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
```

**Recommended squash and merge commit message**

```
* Use f-strings to simplify string formatting
* Use docker login --password-stdin option to avoid warning message:
WARNING! Using --password via the CLI is insecure. Use --password-stdin

New behavior is to have `recast auth setup` print the command:
printf "${RECAST_REGISTRY_PASSWORD}" | docker login --username "${RECAST_REGISTRY_USERNAME}" --password-stdin "${RECAST_REGISTRY_HOST}"
* Add note to users that the environmental variables hold more than just
the Docker password
```