### PR TITLE
build: Update reana-client to v0.8.0+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,7 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        # RE: setuptools c.f. https://github.com/reanahub/reana-client/issues/558
-        python -m pip install --upgrade pip "setuptools<58.0.0" wheel
+        python -m pip install --upgrade pip setuptools wheel
         python -m pip --quiet install --no-cache-dir .[develop,local,kubernetes,reana]
         python -m pip list
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,8 +39,7 @@ RUN apk add --update && \
 WORKDIR /code
 COPY . /code
 
-# c.f. https://github.com/reanahub/reana-client/issues/558
-RUN python3 -m pip --no-cache-dir install --upgrade pip 'setuptools<58.0.0' wheel && \
+RUN python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     python3 -m pip --no-cache-dir install \
         lxml \
         cryptography \

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras_require = {
     'kubernetes': ['kubernetes==9.0.0'],
     'reana': [
         'setuptools<58.0.0',  # c.f. https://github.com/reanahub/reana-client/issues/558
-        'reana-client==0.7.5',
+        'reana-client>=0.8.0',
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,7 @@ extras_require = {
         'pygraphviz',  # from yadage[viz] extra
     ],
     'kubernetes': ['kubernetes==9.0.0'],
-    'reana': [
-        'setuptools<58.0.0',  # c.f. https://github.com/reanahub/reana-client/issues/558
-        'reana-client>=0.8.0',
-    ],
+    'reana': ['reana-client>=0.8.0'],
 }
 
 setup(extras_require=extras_require)


### PR DESCRIPTION
[`reana-client` `v0.8.0`](https://github.com/reanahub/reana-client/releases/tag/0.8.0) is out.

More details also in the release blog https://blog.reana.io/posts/2021/release-0.8.0/

```
* Update reana-client lower bound to v0.8.0 for setuptools stability
   - c.f. https://github.com/reanahub/reana-client/issues/558
* Remove setuptools<58.0.0 cap
```