### PR TITLE
build: Set lower bounds for adage, yadage-schemas, and packtivity

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     jsonschema>=3.0.0
     pyyaml>=5.1  # for parsing CLI options
     six>=1.4.0  # c.f. https://github.com/yadage/yadage-schemas/issues/35
-    yadage-schemas==0.10.6  # lock to yadage
+    yadage-schemas>=0.10.6
 python_requires = >=3.6
 include_package_data = True
 package_dir =

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ extras_require = {
     'develop': {'pytest', 'flake8>=3.9.0', 'black'},
     'local': [
         'pydotplus==2.0.2',
-        'adage==0.10.1',
-        'yadage-schemas==0.10.6',
+        'adage>=0.10.1',
+        'yadage-schemas>=0.10.6',
         'packtivity>=0.14.23',
         'yadage==0.20.1',  # yadage[viz] breaks so install following manually
         'pydot',  # from yadage[viz] extra

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ extras_require = {
     'local': [
         'pydotplus==2.0.2',
         'adage>=0.10.1',
-        'yadage-schemas>=0.10.6',
         'packtivity>=0.14.23',
         'yadage>=0.20.1',  # yadage[viz] breaks so install following manually
         'pydot',  # from yadage[viz] extra

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ extras_require = {
         'pydotplus==2.0.2',
         'adage==0.10.1',
         'yadage-schemas==0.10.6',
-        'packtivity==0.14.23',
+        'packtivity>=0.14.23',
         'yadage==0.20.1',  # yadage[viz] breaks so install following manually
         'pydot',  # from yadage[viz] extra
         'pygraphviz',  # from yadage[viz] extra

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ extras_require = {
         'adage>=0.10.1',
         'yadage-schemas>=0.10.6',
         'packtivity>=0.14.23',
-        'yadage==0.20.1',  # yadage[viz] breaks so install following manually
+        'yadage>=0.20.1',  # yadage[viz] breaks so install following manually
         'pydot',  # from yadage[viz] extra
         'pygraphviz',  # from yadage[viz] extra
     ],


### PR DESCRIPTION
```
* Set lower bound of adage to v0.10.1
* Set lower bound of yadage-schemas to v0.10.6
* Set lower bound of packtivity to v0.14.23
* Relies on reana-commons v0.8.1 allowing for patch releases of yadage
org libraries to float.
    - https://github.com/reanahub/reana-commons/issues/322
    - https://github.com/reanahub/reana-commons/pull/323
```