### PR TITLE
build: Remove explicit six dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,7 @@ install_requires =
     click>=7.0  # for console scripts
     jsonschema>=3.0.0
     pyyaml>=5.1  # for parsing CLI options
-    # c.f. https://github.com/yadage/yadage-schemas/issues/35
-    yadage-schemas>=0.10.6
+    yadage-schemas>=0.10.7  # c.f. https://github.com/yadage/yadage-schemas/issues/35
 python_requires = >=3.6
 include_package_data = True
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     click>=7.0  # for console scripts
     jsonschema>=3.0.0
     pyyaml>=5.1  # for parsing CLI options
-    six>=1.4.0  # c.f. https://github.com/yadage/yadage-schemas/issues/35
+    # c.f. https://github.com/yadage/yadage-schemas/issues/35
     yadage-schemas>=0.10.6
 python_requires = >=3.6
 include_package_data = True


### PR DESCRIPTION
```
* Remove six from install_requires as yadage-schemas v0.10.7 now
defines six>=1.4.0 as as requirement.
* Set lower bound on yadage-schemas of v0.10.7.
* Reverts PR #77
```