### PR TITLE
ci: Add testing for Python 3.9 and Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,11 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install --no-cache-dir .[develop,local,kubernetes,reana]
-        python -m pip list
+        python -m pip --quiet install .[develop,local,kubernetes,reana]
+        python -m pip install --upgrade git+https://github.com/yadage/adage.git
+
+    - name: List installed dependencies
+      run: python -m pip list
 
     - name: Run unit tests
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.6", "3.7", "3.8"]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --quiet install .[develop,local,kubernetes,reana]
+        python -m pip uninstall -y adage
         python -m pip install --upgrade git+https://github.com/yadage/adage.git
 
     - name: List installed dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip --quiet install .[develop,local,kubernetes,reana]
-        python -m pip uninstall -y adage
-        python -m pip install --upgrade git+https://github.com/yadage/adage.git
 
     - name: List installed dependencies
       run: python -m pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - name: Checkout code

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.9"
 
     - name: Install build, check-manifest, and twine
       run: |

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: '3.10'
 
     - name: Install build, check-manifest, and twine
       run: |

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -25,10 +25,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: "3.9"
+        python-version: "3.10"
 
     - name: Install build, check-manifest, and twine
       run: |
@@ -42,7 +42,7 @@ jobs:
 
     - name: Build a sdist and a wheel
       run: |
-        python -m build --outdir dist/ .
+        python -m build .
 
     - name: Verify the distribution
       run: twine check dist/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,8 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Physics


### PR DESCRIPTION
```
* Add Python 3.9 and Python 3.10 to testing in CI
* Use default options for `python -m build`
* Add support for Python 3.9 and Python 3.10 to PyPI classifiers metadata
```