### PR TITLE
ci: Add HEAD of dependencies workflow

### DIFF
--- a/.github/workflows/head-of-dependencies.yml
+++ b/.github/workflows/head-of-dependencies.yml
@@ -1,7 +1,6 @@
 name: HEAD of dependencies
 
 on:
-  push:
   # Run daily at 1:23 UTC
   schedule:
   - cron:  '23 1 * * *'

--- a/.github/workflows/head-of-dependencies.yml
+++ b/.github/workflows/head-of-dependencies.yml
@@ -32,8 +32,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        # python -m pip --quiet install --upgrade --pre .[develop,local,kubernetes,reana]
-        python -m pip install --upgrade --pre .[develop,local,kubernetes,reana]
+        python -m pip --quiet install --upgrade .[develop,local,kubernetes,reana]
+        python -m pip install --upgrade --pre .[local]
 
     - name: List installed dependencies
       run: python -m pip list

--- a/.github/workflows/head-of-dependencies.yml
+++ b/.github/workflows/head-of-dependencies.yml
@@ -1,6 +1,7 @@
 name: HEAD of dependencies
 
 on:
+  push:
   # Run daily at 1:23 UTC
   schedule:
   - cron:  '23 1 * * *'

--- a/.github/workflows/head-of-dependencies.yml
+++ b/.github/workflows/head-of-dependencies.yml
@@ -32,7 +32,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install --upgrade --pre .[develop,local,kubernetes,reana]
+        # python -m pip --quiet install --upgrade --pre .[develop,local,kubernetes,reana]
+        python -m pip install --upgrade --pre .[develop,local,kubernetes,reana]
 
     - name: List installed dependencies
       run: python -m pip list

--- a/.github/workflows/head-of-dependencies.yml
+++ b/.github/workflows/head-of-dependencies.yml
@@ -1,0 +1,146 @@
+name: HEAD of dependencies
+
+on:
+  # Run daily at 1:23 UTC
+  schedule:
+  - cron:  '23 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  release-candidates:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.10']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install external dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y graphviz libgraphviz-dev
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip --quiet install --upgrade --pre .[develop,local,kubernetes,reana]
+
+    - name: List installed dependencies
+      run: python -m pip list
+
+    - name: Run unit tests
+      run: |
+        pytest tests
+
+  adage:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.10']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install external dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y graphviz libgraphviz-dev
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir --quiet install --upgrade .[develop,local,kubernetes,reana]
+        python -m pip uninstall --yes adage
+        python -m pip install --upgrade git+https://github.com/yadage/adage.git
+
+    - name: List installed dependencies
+      run: python -m pip list
+
+    - name: Run unit tests
+      run: |
+        pytest tests
+
+  packtivity:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.10']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install external dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y graphviz libgraphviz-dev
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir --quiet install --upgrade .[develop,local,kubernetes,reana]
+        python -m pip uninstall --yes packtivity
+        python -m pip install --upgrade git+https://github.com/yadage/packtivity.git
+
+    - name: List installed dependencies
+      run: python -m pip list
+
+    - name: Run unit tests
+      run: |
+        pytest tests
+
+  yadage:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.10']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install external dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y graphviz libgraphviz-dev
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip --no-cache-dir --quiet install --upgrade .[develop,local,kubernetes,reana]
+        python -m pip uninstall --yes yadage
+        python -m pip install --upgrade git+https://github.com/yadage/yadage.git
+
+    - name: List installed dependencies
+      run: python -m pip list
+
+    - name: Run unit tests
+      run: |
+        pytest tests


### PR DESCRIPTION
Resolves #97

Nightly test release candidates and yadage org dependencies for 'local' extra.

The HEAD of `yadage` test job is currently failing because of https://github.com/yadage/yadage/issues/116 (and so is expected).

```
* Nightly test release candidates and yadage org dependencies for 'local'
extra.
   - adage, packtivity, and yadage
```