### PR TITLE
build: Require Python 3.7+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -37,7 +36,7 @@ install_requires =
     jsonschema>=3.0.0
     pyyaml>=5.1  # for parsing CLI options
     yadage-schemas>=0.10.7  # c.f. https://github.com/yadage/yadage-schemas/issues/35
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 package_dir =
     = src


### PR DESCRIPTION
* Drop support for Python 3.6 and required Python 3.7+ for use.