### PR TITLE
ci: Use PyPI Trusted Publisher for publishing package

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -5,17 +5,18 @@ on:
     branches:
     - main
     tags:
-      - v*
+    - v*
   pull_request:
     branches:
     - main
+    - release/v*
   release:
     types: [published]
   workflow_dispatch:
 
 jobs:
-  build-and-publish:
-    name: Build and publish Python distro to (Test)PyPI
+  build:
+    name: Build Python distribution
     runs-on: ubuntu-latest
 
     steps:
@@ -25,10 +26,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.x'
 
     - name: Install build, check-manifest, and twine
       run: |
@@ -53,17 +54,45 @@ jobs:
     - name: List contents of wheel
       run: python -m zipfile --list dist/recast_atlas-*.whl
 
+    - name: Upload distribution artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist-artifact
+        path: dist
+
+  publish:
+    name: Publish Python distribution to (Test)PyPI
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    # Mandatory for publishing with a trusted publisher
+    # c.f. https://docs.pypi.org/trusted-publishers/using-a-publisher/
+    permissions:
+      id-token: write
+    # Restrict to the environment set for the trusted publisher
+    environment:
+      name: publish-package
+
+    steps:
+    - name: Download distribution artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: dist-artifact
+        path: dist
+
+    - name: List all files
+      run: ls -lh dist
+
     - name: Publish distribution 📦 to Test PyPI
       # publish to TestPyPI on tag events
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'recast-hep/recast-atlas'
-      uses: pypa/gh-action-pypi-publish@v1.4.2
+      uses: pypa/gh-action-pypi-publish@v1.8.6
       with:
-        password: ${{ secrets.test_pypi_password }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
+        print-hash: true
 
     - name: Publish distribution 📦 to PyPI
-      # publish to PyPI on releases
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'recast-hep/recast-atlas'
-      uses: pypa/gh-action-pypi-publish@v1.4.2
+      uses: pypa/gh-action-pypi-publish@v1.8.6
       with:
-        password: ${{ secrets.pypi_password }}
+        print-hash: true


### PR DESCRIPTION
* Split the build and publish steps into two separate jobs. The 'build' job builds and checks the distributions and then uploads them as a job artifact. The 'publish' job downloads the required artifact from the 'build' job and the publishes them to TestPyPI or PyPI if the typical publishing requirements are met.
* Use the OpenID Connect (OIDC) standard to publish to PyPI and TestPyPI using PyPI's "Trusted Publisher" implementation to publish without using API tokens stored as GitHub Actions secrets. Use an optional GitHub Actions environment to further restrict publishing to selected branches ('main', 'release/*', 'v*') for additional security.
   - c.f. https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
   - c.f. https://docs.pypi.org/trusted-publishers/