### PR TITLE
fix: Make target branch of toplevel explicit in examples

### DIFF
--- a/src/recastatlas/data/catalogue/atlas_atlas_conf_2018_041.yml
+++ b/src/recastatlas/data/catalogue/atlas_atlas_conf_2018_041.yml
@@ -4,7 +4,7 @@ metadata:
   short_description: ATLAS MBJ
 
 spec:
-  toplevel: gitlab-cern:recast-atlas/susy/ATLAS-CONF-2018-041:specs
+  toplevel: gitlab-cern:recast-atlas/susy/ATLAS-CONF-2018-041@master:specs
   workflow: workflow.yml
 
 example_inputs:

--- a/src/recastatlas/data/catalogue/busyboxtest.yml
+++ b/src/recastatlas/data/catalogue/busyboxtest.yml
@@ -6,7 +6,7 @@ metadata:
   short_description: Simple, lightweight Functionality Test
 
 spec:
-  toplevel: 'github:yadage/yadage-workflows:testing/busybox-flow'
+  toplevel: 'github:yadage/yadage-workflows@main:testing/busybox-flow'
   workflow: rootflow.yml
 
 example_inputs:

--- a/src/recastatlas/data/catalogue/examples_checkmate1.yml
+++ b/src/recastatlas/data/catalogue/examples_checkmate1.yml
@@ -5,7 +5,7 @@ metadata:
   short_description: CheckMate Tutorial Example (Herwig + CM1)
 
 spec:
-  toplevel: github:lukasheinrich/yadage-workflows:phenochain/checkmate_workflow
+  toplevel: github:lukasheinrich/yadage-workflows@master:phenochain/checkmate_workflow
   workflow: checkmate_lxplus.yml
 
 example_inputs:

--- a/src/recastatlas/data/catalogue/examples_checkmate2.yml
+++ b/src/recastatlas/data/catalogue/examples_checkmate2.yml
@@ -6,7 +6,7 @@ metadata:
   short_description: CheckMate Tutorial Example (Herwig + CM2)
 
 spec:
-  toplevel: github:lukasheinrich/yadage-workflows:phenochain/checkmate_workflow
+  toplevel: github:lukasheinrich/yadage-workflows@master:phenochain/checkmate_workflow
   workflow: checkmate2_lxplus.yml
 
 example_inputs:

--- a/src/recastatlas/data/catalogue/examples_rome.yml
+++ b/src/recastatlas/data/catalogue/examples_rome.yml
@@ -6,7 +6,7 @@ metadata:
   short_description: Example from ATLAS Exotics Rome Workshop 2018
 
 spec:
-  toplevel: github:reanahub/reana-demo-atlas-recast
+  toplevel: github:reanahub/reana-demo-atlas-recast@master
   workflow: workflow/workflow.yml
 
 example_inputs:


### PR DESCRIPTION
* Explicitly state the branch name for the `<username/repo[@branch]>[:subpath]` pattern.

c.f. https://github.com/reanahub/reana-demo-atlas-recast/issues/43.