### PR TITLE
build: Require Python 3.8+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
     - name: Checkout code

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -36,7 +36,7 @@ install_requires =
     jsonschema>=3.0.0
     pyyaml>=5.1  # for parsing CLI options
     yadage-schemas>=0.10.7  # c.f. https://github.com/yadage/yadage-schemas/issues/35
-python_requires = >=3.7
+python_requires = >=3.8
 include_package_data = True
 package_dir =
     = src


### PR DESCRIPTION
* Drop support for Python 3.7 and require Python 3.8+ for use.