### PR TITLE
build: Require yadage v0.21.0+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ from setuptools import setup
 extras_require = {
     'develop': {'pytest', 'flake8>=3.9.0', 'black'},
     'local': [
+        'yadage>=0.21.0',  # yadage[viz] breaks so install following manually
+        'adage',  # compatible versions controlled through yadage
+        'packtivity',  # compatible versions controlled through yadage
         'pydotplus==2.0.2',
-        'adage>=0.10.1',
-        'packtivity>=0.14.23',
-        'yadage>=0.20.1',  # yadage[viz] breaks so install following manually
         'pydot',  # from yadage[viz] extra
         'pygraphviz',  # from yadage[viz] extra
     ],


### PR DESCRIPTION
* Require yadage v0.21.0+ to ensure packtivity>=0.16.2 is used to properly handle jqlang v1.6/v1.7.
* As yadage handles the lower bounds of adage and packtivity, remove their stated lower bound to let the dependency resolver have yadage do all the work.