### PR TITLE
ci: Remove 'kubernetes' extra from testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install .[develop,local,kubernetes,reana]
+        python -m pip --quiet install .[develop,local,reana]
 
     - name: List installed dependencies
       run: python -m pip list

--- a/.github/workflows/head-of-dependencies.yml
+++ b/.github/workflows/head-of-dependencies.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install --upgrade .[develop,local,kubernetes,reana]
+        python -m pip --quiet install --upgrade .[develop,local,reana]
         python -m pip install --upgrade --pre .[local]
 
     - name: List installed dependencies
@@ -65,7 +65,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade .[develop,local,kubernetes,reana]
+        python -m pip --no-cache-dir --quiet install --upgrade .[develop,local,reana]
         python -m pip uninstall --yes adage
         python -m pip install --upgrade git+https://github.com/yadage/adage.git
 
@@ -100,7 +100,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade .[develop,local,kubernetes,reana]
+        python -m pip --no-cache-dir --quiet install --upgrade .[develop,local,reana]
         python -m pip uninstall --yes packtivity
         python -m pip install --upgrade git+https://github.com/yadage/packtivity.git
 
@@ -135,7 +135,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade .[develop,local,kubernetes,reana]
+        python -m pip --no-cache-dir --quiet install --upgrade .[develop,local,reana]
         python -m pip uninstall --yes yadage
         python -m pip install --upgrade git+https://github.com/yadage/yadage.git
 


### PR DESCRIPTION
* As unused, don't need to add additional package solve constraints during tests.