### PR TITLE
feat: Set docker platform from DOCKER_DEFAULT_PLATFORM env variable

### DIFF
--- a/src/recastatlas/backends/docker.py
+++ b/src/recastatlas/backends/docker.py
@@ -38,6 +38,11 @@ def setup_docker():
         "/var/run/docker.sock:/var/run/docker.sock",
     ]
 
+    # Set from DOCKER_DEFAULT_PLATFORM environment variable if it exists
+    if "platform" in config.backends[backend]:
+        if _platform := config.backends[backend]["platform"]:
+            command += ["--platform", _platform]
+
     if "cvmfs" in config.backends[backend]:
         command += [
             "-e",

--- a/src/recastatlas/config.py
+++ b/src/recastatlas/config.py
@@ -46,6 +46,7 @@ class Config:
                 "image": conf_from_env(
                     "RECAST_DOCKER_IMAGE", "recast/recastatlas:v0.3.0"
                 ),
+                "platform": conf_from_env("DOCKER_DEFAULT_PLATFORM"),
                 "cvmfs": {"location": "/cvmfs", "propagation": "rprivate"},
                 "reg": {
                     "user": conf_from_env("RECAST_REGISTRY_USERNAME"),


### PR DESCRIPTION
Resolves #128 

* If the environment variable `DOCKER_DEFAULT_PLATFORM` exists use it to set the `--platform` option for `docker run`. This is required to be able to run on other platform than the native host's with emulation.
   - c.f. https://docs.docker.com/engine/reference/commandline/cli/#environment-variables