### PR TITLE
ci: Enable multiplatform builds for amd64 and arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -100,6 +100,7 @@ jobs:
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
           push: true
+          platforms: linux/amd64,linux/arm64
 
       - name: Build and publish to registry with release tag
         if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'recast-hep/recast-atlas'
@@ -114,3 +115,4 @@ jobs:
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
           push: true
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
* Add the 'platforms' argument to the docker/build-push-action GitHub Action and pass the platform names to enable build for both amd64 and arm64 architectures. This will enable Apple silicon machines to run the Docker images without emulation which will significantly improve runtime performance.