### PR TITLE
ci: Use uv for all pip installs

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -26,9 +26,10 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install "bump2version~=1.0"
-        python -m pip list
+        python -m pip install uv
+        uv pip install --system --upgrade wheel
+        uv pip install --system "bump2version~=1.0"
+        uv pip list --system
 
     - name: Setup Git
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,12 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install .[develop,local,reana]
+        python -m pip install uv
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system '.[develop,local,reana]'
 
     - name: List installed dependencies
-      run: python -m pip list
+      run: uv pip list --system
 
     - name: Run unit tests
       run: |

--- a/.github/workflows/head-of-dependencies.yml
+++ b/.github/workflows/head-of-dependencies.yml
@@ -30,12 +30,13 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install --upgrade .[develop,local,reana]
-        python -m pip install --upgrade --pre .[local]
+        python -m pip install uv
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade '.[develop,local,reana]'
+        uv pip install --system --upgrade --pre '.[local]'
 
     - name: List installed dependencies
-      run: python -m pip list
+      run: uv pip list --system
 
     - name: Run unit tests
       run: |
@@ -64,13 +65,14 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade .[develop,local,reana]
-        python -m pip uninstall --yes adage
-        python -m pip install --upgrade git+https://github.com/yadage/adage.git
+        python -m pip install uv
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade '.[develop,local,reana]'
+        uv pip uninstall --system adage
+        uv pip install --system --upgrade git+https://github.com/yadage/adage.git
 
     - name: List installed dependencies
-      run: python -m pip list
+      run: uv pip list --system
 
     - name: Run unit tests
       run: |
@@ -99,13 +101,14 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade .[develop,local,reana]
-        python -m pip uninstall --yes packtivity
-        python -m pip install --upgrade git+https://github.com/yadage/packtivity.git
+        python -m pip install uv
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade '.[develop,local,reana]'
+        uv pip uninstall --system packtivity
+        uv pip install --system --upgrade git+https://github.com/yadage/packtivity.git
 
     - name: List installed dependencies
-      run: python -m pip list
+      run: uv pip list --system
 
     - name: Run unit tests
       run: |
@@ -134,13 +137,14 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip --no-cache-dir --quiet install --upgrade .[develop,local,reana]
-        python -m pip uninstall --yes yadage
-        python -m pip install --upgrade git+https://github.com/yadage/yadage.git
+        python -m pip install uv
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade '.[develop,local,reana]'
+        uv pip uninstall --system yadage
+        uv pip install --system --upgrade git+https://github.com/yadage/yadage.git
 
     - name: List installed dependencies
-      run: python -m pip list
+      run: uv pip list --system
 
     - name: Run unit tests
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,9 +23,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip --quiet install --upgrade .[develop]
-        python -m pip list
+        python -m pip install uv
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade '.[develop]'
+        uv pip list --system
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -33,9 +33,10 @@ jobs:
 
     - name: Install build, check-manifest, and twine
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install build check-manifest twine
-        python -m pip list
+        python -m pip install uv
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system build check-manifest twine
+        uv pip list --system
 
     - name: Check MANIFEST
       run: |


### PR DESCRIPTION
* Use 'uv pip' for all calls to 'pip install' and 'pip uninstall' in CI workflows.
   - c.f. https://github.com/astral-sh/uv/