### PR TITLE
fix: Use importlib-resources over deprecated pkg_resources

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     jsonschema>=3.0.0
     pyyaml>=5.1  # for parsing CLI options
     yadage-schemas>=0.10.7  # c.f. https://github.com/yadage/yadage-schemas/issues/35
-    importlib-resources>=1.3  # for accessing package filepaths
+    importlib-resources>=5.10;python_version<'3.9'  # for accessing package filepaths
 python_requires = >=3.8
 include_package_data = True
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     jsonschema>=3.0.0
     pyyaml>=5.1  # for parsing CLI options
     yadage-schemas>=0.10.7  # c.f. https://github.com/yadage/yadage-schemas/issues/35
+    importlib-resources>=1.3
 python_requires = >=3.8
 include_package_data = True
 package_dir =

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     jsonschema>=3.0.0
     pyyaml>=5.1  # for parsing CLI options
     yadage-schemas>=0.10.7  # c.f. https://github.com/yadage/yadage-schemas/issues/35
-    importlib-resources>=1.3
+    importlib-resources>=1.3  # for accessing package filepaths
 python_requires = >=3.8
 include_package_data = True
 package_dir =

--- a/src/recastatlas/config.py
+++ b/src/recastatlas/config.py
@@ -1,7 +1,13 @@
 import glob
 import logging
 import os
-from importlib.resources import files
+
+try:
+    from importlib.resources import files
+except ImportError:
+    # Support Python 3.8 as importlib.resources added in Python 3.9
+    # https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files
+    from importlib_resources import files
 
 import jsonschema
 import yaml

--- a/src/recastatlas/config.py
+++ b/src/recastatlas/config.py
@@ -1,9 +1,10 @@
-import os
-import yaml
-import pkg_resources
 import glob
 import logging
+import os
+from importlib.resources import files
+
 import jsonschema
+import yaml
 
 log = logging.getLogger(__name__)
 
@@ -73,11 +74,7 @@ class Config:
         }
 
     def catalogue_paths(self, include_default=True):
-        paths = (
-            [pkg_resources.resource_filename("recastatlas", "data/catalogue")]
-            if include_default
-            else []
-        )
+        paths = [files("recastatlas") / "data/catalogue"] if include_default else []
         configpath = os.environ.get("RECAST_ATLAS_CATALOGUE")
 
         if configpath:

--- a/src/recastatlas/subcommands/auth.py
+++ b/src/recastatlas/subcommands/auth.py
@@ -2,7 +2,13 @@ import os
 import re
 import shutil
 import sys
-from importlib.resources import files
+
+try:
+    from importlib.resources import files
+except ImportError:
+    # Support Python 3.8 as importlib.resources added in Python 3.9
+    # https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files
+    from importlib_resources import files
 
 import click
 

--- a/src/recastatlas/subcommands/auth.py
+++ b/src/recastatlas/subcommands/auth.py
@@ -1,9 +1,11 @@
-import click
-import sys
 import os
 import re
 import shutil
-import pkg_resources
+import sys
+from importlib.resources import files
+
+import click
+
 from ..backends import run_sync_packtivity
 from ..config import config
 
@@ -132,11 +134,11 @@ def write(basedir):
     )
 
     shutil.copy(
-        pkg_resources.resource_filename("recastatlas", "data/getkrb_reana.sh"),
+        files("recastatlas") / "data/getkrb_reana.sh",
         os.path.join(basedir, "getkrb_reana.sh"),
     )
     shutil.copy(
-        pkg_resources.resource_filename("recastatlas", "data/expect_script.sh"),
+        files("recastatlas") / "data/expect_script.sh",
         os.path.join(basedir, "expect_script.sh"),
     )
     click.echo(

--- a/src/recastatlas/subcommands/catalogue.py
+++ b/src/recastatlas/subcommands/catalogue.py
@@ -1,16 +1,15 @@
+import getpass
+import logging
+import os
+import string
+from distutils.dir_util import copy_tree
+from importlib.resources import files
+
 import click
 import yaml
-import os
-from distutils.dir_util import copy_tree
-import string
-import logging
-
-import pkg_resources
-import getpass
 
 from ..config import config
 from ..testing import validate_entry
-
 
 log = logging.getLogger(__name__)
 default_meta = {"author": "unknown", "short_description": "no description", "tags": []}
@@ -37,9 +36,8 @@ def check(name):
 @click.argument("name")
 @click.argument("path")
 def create(name, path):
-    template_path = pkg_resources.resource_filename(
-        "recastatlas", "data/templates/helloworld"
-    )
+
+    template_path = files("recastatlas") / "data/templates/helloworld"
     copy_tree(template_path, path)
     recast_file = os.path.join(path, "recast.yml")
     data = string.Template(open(recast_file).read()).safe_substitute(

--- a/src/recastatlas/subcommands/catalogue.py
+++ b/src/recastatlas/subcommands/catalogue.py
@@ -3,7 +3,13 @@ import logging
 import os
 import string
 from distutils.dir_util import copy_tree
-from importlib.resources import files
+
+try:
+    from importlib.resources import files
+except ImportError:
+    # Support Python 3.8 as importlib.resources added in Python 3.9
+    # https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files
+    from importlib_resources import files
 
 import click
 import yaml


### PR DESCRIPTION
Addresses part of Issue #137 

```
* Add importlib-resources as an install dependency for Python 3.8 as Python 3.12 deprecates
  and removes pkg_resources.
* Replace use of pkg_resources.resource_filename with importlib.resources.files
  for Python 3.9+ and importlib_resources.files for Python 3.8.
* Apply isort.
```