### PR TITLE
chore: Use uv during Dockerfile build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,7 @@ COPY . /code
 # FIXME: Use a virtual environment
 RUN python3 -m pip --no-cache-dir install --upgrade uv && \
     uv --no-cache pip install --system --upgrade pip setuptools wheel && \
-    python3 -m pip --no-cache-dir install \
+    uv --no-cache pip install --system \
         lxml \
         cryptography \
         jq && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,12 +39,14 @@ RUN apk add --update && \
 WORKDIR /code
 COPY . /code
 
-RUN python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
-    python3 -m pip --no-cache-dir install \
+# FIXME: Use a virtual environment
+RUN python3 -m pip --no-cache-dir install --upgrade uv && \
+    uv --no-cache pip install --system --upgrade pip setuptools wheel && \
+    uv --no-cache pip install --system \
         lxml \
         cryptography \
         jq && \
-    python3 -m pip --no-cache-dir install .[local,kubernetes,reana]
+    uv --no-cache pip install --system '.[local,kubernetes,reana]'
 
 ENV PACKTIVITY_DOCKER_CMD_MOD "-u root"
 ENV PACKTIVITY_CVMFS_LOCATION /shared-mounts/cvmfs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,8 +39,10 @@ RUN apk add --update && \
 WORKDIR /code
 COPY . /code
 
-# FIXME: Use a virtual environment
-RUN python3 -m pip --no-cache-dir install --upgrade uv && \
+ENV PATH=/usr/local/venv/bin:"${PATH}"
+RUN python3 -m venv /usr/local/venv && \
+    . /usr/local/venv/bin/activate && \
+    python -m pip --no-cache-dir install --upgrade uv && \
     uv --no-cache pip install --system --upgrade pip setuptools wheel && \
     uv --no-cache pip install --system \
         lxml \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,7 @@ COPY . /code
 # FIXME: Use a virtual environment
 RUN python3 -m pip --no-cache-dir install --upgrade uv && \
     uv --no-cache pip install --system --upgrade pip setuptools wheel && \
-    uv --no-cache pip install --system \
+    python3 -m pip --no-cache-dir install \
         lxml \
         cryptography \
         jq && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,8 @@ RUN python3 -m venv /usr/local/venv && \
         lxml \
         cryptography \
         jq && \
-    uv --no-cache pip install --system '.[local,kubernetes,reana]'
+    uv --no-cache pip install --system '.[local,kubernetes,reana]' && \
+    recast --help
 
 ENV PACKTIVITY_DOCKER_CMD_MOD "-u root"
 ENV PACKTIVITY_CVMFS_LOCATION /shared-mounts/cvmfs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,12 +43,12 @@ ENV PATH=/usr/local/venv/bin:"${PATH}"
 RUN python3 -m venv /usr/local/venv && \
     . /usr/local/venv/bin/activate && \
     python -m pip --no-cache-dir install --upgrade uv && \
-    uv --no-cache pip install --system --upgrade pip setuptools wheel && \
-    uv --no-cache pip install --system \
+    uv --no-cache pip install --upgrade pip setuptools wheel && \
+    uv --no-cache pip install \
         lxml \
         cryptography \
         jq && \
-    uv --no-cache pip install --system '.[local,kubernetes,reana]' && \
+    uv --no-cache pip install '.[local,kubernetes,reana]' && \
     recast --help
 
 ENV PACKTIVITY_DOCKER_CMD_MOD "-u root"


### PR DESCRIPTION
* Speed up the Dockerfile build by using uv to install all Python dependencies.
* Set PATH to include a default virtual environment and install Python dependencies inside the virtual environment at /usr/local/venv.