### PR TITLE
ci: Use pip install for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,21 @@ jobs:
         sudo apt-get install -y graphviz libgraphviz-dev
 
     - name: Install Python dependencies
+      if: matrix.python-version != '3.12'
       run: |
         python -m pip install uv
         uv pip install --system --upgrade pip setuptools wheel
         uv pip install --system '.[develop,local,reana]'
 
+      # c.f. https://github.com/astral-sh/uv/issues/4333
+    - name: Install dependencies (Python 3.12)
+      if: matrix.python-version == '3.12'
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade '.[develop,local,reana]'
+
     - name: List installed dependencies
-      run: uv pip list --system
+      run: python -m pip list
 
     - name: Run unit tests
       run: |


### PR DESCRIPTION
* Python 3.12 installs with uv are currently unreliable, so fall back to using pip.
   - c.f. https://github.com/astral-sh/uv/issues/4333