### PR TITLE
docs: Add additional run requirements to 'local' and 'reana' backend examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Commands:
 
 #### Local backend
 
-**Example**: Run the example from the [ATLAS Exotics Rome Workshop 2018][ATLAS Exotics Workshop 2018] using the `local` backend.
+**Example**: Run the [example][recast-examples-rome] from the [ATLAS Exotics Rome Workshop 2018][ATLAS Exotics Workshop 2018] using the `local` backend.
 
 Install `recast-atlas` with the `local` extra
 
@@ -67,7 +67,7 @@ The `local` backend orchestrates the workflow graph locally, but note that the d
 
 #### REANA cluster backend
 
-**Example**: Asynchronously run the example from the [ATLAS Exotics Rome Workshop 2018][ATLAS Exotics Workshop 2018] using the `reana` backend.
+**Example**: Asynchronously run the [example][recast-examples-rome] from the [ATLAS Exotics Rome Workshop 2018][ATLAS Exotics Workshop 2018] using the `reana` backend.
 
 Install `recast-atlas` with the `reana` extra
 
@@ -131,3 +131,5 @@ source ~recast/public/setup.sh
 recast catalogue ls
 recast run examples/rome
 ```
+
+[recast-examples-rome]: https://github.com/recast-hep/recast-atlas/blob/de61902bc6a66104965cced12471a8f195075bb3/src/recastatlas/data/catalogue/examples_rome.yml

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ Commands:
 Run the example from the [ATLAS Exotics Rome Workshop 2018][ATLAS Exotics Workshop 2018] using the `local` backend:
 
 ```
-python -m pip install --upgrade 'recast-atlas[local]'
+python -m pip install --upgrade 'recast-atlas[local]' coolname
 ```
 
 ```
-recast run examples/rome --backend local
+PACKTIVITY_DOCKER_CMD_MOD="-u root" recast run examples/rome --backend local --tag "$(coolname 2)"
 ```
 
 #### REANA cluster backend

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ python -m pip install --upgrade 'recast-atlas[local]' coolname
 ```
 
 ```
-PACKTIVITY_DOCKER_CMD_MOD="-u root" recast run examples/rome --backend local --tag "$(coolname 2)"
+PACKTIVITY_DOCKER_CMD_MOD="-u root" recast run examples/rome --backend local --tag "local-$(coolname 2)"
 ```
 
 #### REANA cluster backend
@@ -64,11 +64,11 @@ PACKTIVITY_DOCKER_CMD_MOD="-u root" recast run examples/rome --backend local --t
 Asynchronously run the example from the [ATLAS Exotics Rome Workshop 2018][ATLAS Exotics Workshop 2018] using the `reana` backend:
 
 ```
-python -m pip install --upgrade 'recast-atlas[reana]'
+python -m pip install --upgrade 'recast-atlas[reana]' coolname
 ```
 
 ```
-recast submit examples/rome --backend reana
+recast submit examples/rome --backend reana --tag "reana-$(coolname 2)"
 ```
 
 [ATLAS Exotics Workshop 2018]: https://indico.cern.ch/event/710748/contributions/2982534/subcontributions/254796

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Asynchronously run the example from the [ATLAS Exotics Rome Workshop 2018][ATLAS
 python -m pip install --upgrade 'recast-atlas[reana]' coolname
 ```
 
+Authenticate to use the REANA cluster
 ```
 # Set these variables to your personal secret values
 export RECAST_AUTH_USERNAME="<your RECAST auth username>"
@@ -81,7 +82,23 @@ export REANA_ACCESS_TOKEN="<your RECAST access token>"
 ```
 
 ```
-recast submit examples/rome --backend reana --tag "reana-$(coolname 2)"
+reana_tag="reana-$(coolname 2)"
+recast submit examples/rome --backend reana --tag "${reana_tag}"
+export REANA_WORKON="recast-${reana_tag}"  # REANA_WORKON is a helper variable that sets workflow automatically
+```
+
+Check on the state of the REANA workflow
+
+```
+reana-client status
+# reana-client status --workflow "<use the created tag>"  # if REANA_WORKON not set
+```
+
+Download the results after the workflow succeeds
+
+```
+reana-client download --output-directory output
+# reana-client download --workflow "<use the created tag>" --output-directory output
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ Asynchronously run the example from the [ATLAS Exotics Rome Workshop 2018][ATLAS
 python -m pip install --upgrade 'recast-atlas[reana]' coolname
 ```
 
-Authenticate to use the REANA cluster
-```
+Authenticate to use the REANA cluster (remember to clean up later with `eval $(recast auth destroy)`)
+
+```console
 # Set these variables to your personal secret values
 export RECAST_AUTH_USERNAME="<your RECAST auth username>"
 export RECAST_AUTH_PASSWORD="<your RECAST auth password>"
@@ -81,29 +82,34 @@ export REANA_SERVER_URL=https://reana.cern.ch
 export REANA_ACCESS_TOKEN="<your RECAST access token>"
 ```
 
-```
+Submit your RECAST workflow to the REANA cluster
+
+```console
 reana_tag="reana-$(coolname 2)"
 recast submit examples/rome --backend reana --tag "${reana_tag}"
-export REANA_WORKON="recast-${reana_tag}"  # REANA_WORKON is a helper variable that sets workflow automatically
+# REANA_WORKON sets the workflow automatically
+export REANA_WORKON="recast-${reana_tag}"
 ```
 
-Check on the state of the REANA workflow
+Monitor the state of the workflow on REANA
 
-```
+```console
 reana-client status
-# reana-client status --workflow "<use the created tag>"  # if REANA_WORKON not set
+# or if REANA_WORKON not set
+# reana-client status --workflow "<the created tag>"
 ```
 
-Download the results after the workflow succeeds
+The `examples/rome` example doesn't have any result files, but if it did you can download the results after the workflow succeeds
 
-```
+```console
 reana-client download --output-directory output
-# reana-client download --workflow "<use the created tag>" --output-directory output
+# or if REANA_WORKON not set
+# reana-client download --workflow "<the created tag>" --output-directory output
 ```
 
 Clean up the environment of personal information in environmental variables
 
-```
+```console
 eval $(recast auth destroy)
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,19 +49,27 @@ Commands:
 
 #### Local backend
 
-Run the example from the [ATLAS Exotics Rome Workshop 2018][ATLAS Exotics Workshop 2018] using the `local` backend:
+**Example**: Run the example from the [ATLAS Exotics Rome Workshop 2018][ATLAS Exotics Workshop 2018] using the `local` backend.
+
+Install `recast-atlas` with the `local` extra
 
 ```
 python -m pip install --upgrade 'recast-atlas[local]' coolname
 ```
 
+Submit the RECAST workflow to run locally
+
 ```
 PACKTIVITY_DOCKER_CMD_MOD="-u root" recast run examples/rome --backend local --tag "local-$(coolname 2)"
 ```
 
+The `local` backend orchestrates the workflow graph locally, but note that the different workflow steps still run in Linux containers.
+
 #### REANA cluster backend
 
-Asynchronously run the example from the [ATLAS Exotics Rome Workshop 2018][ATLAS Exotics Workshop 2018] using the `reana` backend:
+**Example**: Asynchronously run the example from the [ATLAS Exotics Rome Workshop 2018][ATLAS Exotics Workshop 2018] using the `reana` backend.
+
+Install `recast-atlas` with the `reana` extra
 
 ```
 python -m pip install --upgrade 'recast-atlas[reana]' coolname
@@ -82,7 +90,7 @@ export REANA_SERVER_URL=https://reana.cern.ch
 export REANA_ACCESS_TOKEN="<your RECAST access token>"
 ```
 
-Submit your RECAST workflow to the REANA cluster
+Submit the RECAST workflow to the REANA cluster
 
 ```
 reana_tag="reana-$(coolname 2)"
@@ -99,7 +107,7 @@ reana-client status
 # reana-client status --workflow "<the created tag>"
 ```
 
-The `examples/rome` example doesn't have any result files, but if it did you can download the results after the workflow succeeds
+The `examples/rome` example doesn't have any result files, but if it did, you can download the results after the workflow succeeds
 
 ```
 reana-client download --output-directory output

--- a/README.md
+++ b/README.md
@@ -68,7 +68,25 @@ python -m pip install --upgrade 'recast-atlas[reana]' coolname
 ```
 
 ```
+# Set these variables to your personal secret values
+export RECAST_AUTH_USERNAME="<your RECAST auth username>"
+export RECAST_AUTH_PASSWORD="<your RECAST auth password>"
+export RECAST_AUTH_TOKEN="<your RECAST auth token>"
+
+eval "$(recast auth setup -a ${RECAST_AUTH_USERNAME} -a ${RECAST_AUTH_PASSWORD} -a ${RECAST_AUTH_TOKEN} -a default)"
+eval "$(recast auth write --basedir authdir)"
+
+export REANA_SERVER_URL=https://reana.cern.ch
+export REANA_ACCESS_TOKEN="<your RECAST access token>"
+```
+
+```
 recast submit examples/rome --backend reana --tag "reana-$(coolname 2)"
+```
+
+```
+# Clean up the environment of personal information in environmental variables
+eval $(recast auth destroy)
 ```
 
 [ATLAS Exotics Workshop 2018]: https://indico.cern.ch/event/710748/contributions/2982534/subcontributions/254796

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ python -m pip install --upgrade 'recast-atlas[reana]' coolname
 
 Authenticate to use the REANA cluster (remember to clean up later with `eval $(recast auth destroy)`)
 
-```console
+```
 # Set these variables to your personal secret values
 export RECAST_AUTH_USERNAME="<your RECAST auth username>"
 export RECAST_AUTH_PASSWORD="<your RECAST auth password>"
@@ -84,7 +84,7 @@ export REANA_ACCESS_TOKEN="<your RECAST access token>"
 
 Submit your RECAST workflow to the REANA cluster
 
-```console
+```
 reana_tag="reana-$(coolname 2)"
 recast submit examples/rome --backend reana --tag "${reana_tag}"
 # REANA_WORKON sets the workflow automatically
@@ -93,7 +93,7 @@ export REANA_WORKON="recast-${reana_tag}"
 
 Monitor the state of the workflow on REANA
 
-```console
+```
 reana-client status
 # or if REANA_WORKON not set
 # reana-client status --workflow "<the created tag>"
@@ -101,7 +101,7 @@ reana-client status
 
 The `examples/rome` example doesn't have any result files, but if it did you can download the results after the workflow succeeds
 
-```console
+```
 reana-client download --output-directory output
 # or if REANA_WORKON not set
 # reana-client download --workflow "<the created tag>" --output-directory output
@@ -109,7 +109,7 @@ reana-client download --output-directory output
 
 Clean up the environment of personal information in environmental variables
 
-```console
+```
 eval $(recast auth destroy)
 ```
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ reana-client download --output-directory output
 # reana-client download --workflow "<use the created tag>" --output-directory output
 ```
 
+Clean up the environment of personal information in environmental variables
+
 ```
-# Clean up the environment of personal information in environmental variables
 eval $(recast auth destroy)
 ```
 


### PR DESCRIPTION
Provides a workaround for Issue https://github.com/recast-hep/recast-atlas/issues/51 and https://github.com/recast-hep/recast-atlas/issues/118.

* To have the local backend run correctly it requires the Linux containers being executed to be root. To ensure this, set the `PACKTIVITY_DOCKER_CMD_MOD` environmental variable to `"-u root"`.
* Add environmental setup instructions for the `reana` backend example.
* Add `coolname` in install example and use it for the local backend tag.
* Add additional explanations to both the `local` and `reana` backend examples.

```
* To have the local backend run correctly it requires the Linux containers being
  executed to be root. To ensure this, set the 'PACKTIVITY_DOCKER_CMD_MOD'
  environment variable to "-u root".
* Add environmental setup instructions for the 'reana' backend example.
* Add 'coolname' in install example and use it for the local backend tag.
* Add additional explanations to both the 'local' and 'reana' backend examples.
```