### PR TITLE
ci: Use snakemake lower bound to force uv solve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,18 +36,11 @@ jobs:
         sudo apt-get install -y graphviz libgraphviz-dev
 
     - name: Install Python dependencies
-      if: matrix.python-version != '3.12'
+      # c.f. https://github.com/astral-sh/uv/issues/4333 for why snakemake lower bound
       run: |
         python -m pip install uv
         uv pip install --system --upgrade pip setuptools wheel
-        uv pip install --system '.[develop,local,reana]'
-
-      # c.f. https://github.com/astral-sh/uv/issues/4333
-    - name: Install dependencies (Python 3.12)
-      if: matrix.python-version == '3.12'
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade '.[develop,local,reana]'
+        uv pip install --system '.[develop,local,reana]' 'snakemake>6.8.0'
 
     - name: List installed dependencies
       run: python -m pip list


### PR DESCRIPTION
* To avoid backtracking issues (https://github.com/astral-sh/uv/issues/4333), place a lower bound on `snakemake` to bounce `uv` into the correct resolution path.

Thanks to @zanieb for this fix. :+1: 