### PR TITLE
ci: Remove setuptools install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       # c.f. https://github.com/astral-sh/uv/issues/4333 for why snakemake lower bound
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         uv pip install --system '.[develop,local,reana]' 'snakemake>6.8.0'
 
     - name: List installed dependencies

--- a/.github/workflows/head-of-dependencies.yml
+++ b/.github/workflows/head-of-dependencies.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         uv pip install --system --upgrade '.[develop,local,reana]'
         uv pip install --system --upgrade --pre '.[local]'
 
@@ -66,7 +66,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         uv pip install --system --upgrade '.[develop,local,reana]'
         uv pip uninstall --system adage
         uv pip install --system --upgrade git+https://github.com/yadage/adage.git
@@ -102,7 +102,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         uv pip install --system --upgrade '.[develop,local,reana]'
         uv pip uninstall --system packtivity
         uv pip install --system --upgrade git+https://github.com/yadage/packtivity.git
@@ -138,7 +138,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         uv pip install --system --upgrade '.[develop,local,reana]'
         uv pip uninstall --system yadage
         uv pip install --system --upgrade git+https://github.com/yadage/yadage.git

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install build and twine
       run: |
         python -m pip install uv
-        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip wheel
         uv pip install --system build twine
         uv pip list --system
 


### PR DESCRIPTION
* As recast-atlas is hatchling based now, setuptools isn't required.