### PR TITLE
chore: Use Ruff for linting and formatting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-# E501: line too long
-extend-ignore = E501
-count = True
-statistics = True

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,10 +21,6 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: Lint with flake8
+    - name: Lint with Ruff
       run: |
-        pipx run flake8 .
-
-    - name: Lint with Black
-      run: |
-        pipx run black --check --diff --verbose .
+        pipx run ruff check --diff --verbose .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff
-        args: [ --fix ]
+        args: ["--fix", "--show-fixes"]
       # Run the formatter.
       - id: ruff-format
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,12 +21,6 @@ repos:
       exclude: ^deploy/
     - id: trailing-whitespace
 
--   repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.2
-    hooks:
-    - id: pyupgrade
-      args: ["--py36-plus"]
-
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.4.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,15 +27,15 @@ repos:
     - id: pyupgrade
       args: ["--py36-plus"]
 
--   repo: https://github.com/psf/black
-    rev: 24.3.0
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.4.9
     hooks:
-    - id: black-jupyter
-
--   repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
-    hooks:
-    - id: flake8
+      # Run the linter.
+      - id: ruff
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format
 
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.2.6

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/recast-hep/recast-atlas/main.svg)](https://results.pre-commit.ci/latest/github/recast-hep/recast-atlas/main)
 [![PyPI version](https://badge.fury.io/py/recast-atlas.svg)](https://badge.fury.io/py/recast-atlas)
 
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+
 ATLAS tools to facilitate integration of ATLAS analyses into RECAST
 
 ## Getting Started

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ ignore = [
   "PLR09",    # Too many <...>
   "PLR2004",  # Magic value used in comparison
   "ISC001",   # Conflicts with formatter
-  # FIXME:
+  # FIXME: Ingores are to cover over failing checks at Ruff adoption point
   "C414",
   "EM101",
   "EM103",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,15 +99,3 @@ only-include = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/recastatlas"]
-
-[tool.black]
-line-length = 88
-skip-string-normalization = true
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.git
-  | .eggs
-  | build
-)/
-'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,3 +99,42 @@ only-include = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/recastatlas"]
+
+[tool.ruff]
+src = ["src"]
+
+[tool.ruff.lint]
+extend-select = [
+  "B",        # flake8-bugbear
+  "I",        # isort
+  "ARG",      # flake8-unused-arguments
+  "C4",       # flake8-comprehensions
+  "EM",       # flake8-errmsg
+  "ICN",      # flake8-import-conventions
+  "G",        # flake8-logging-format
+  "PGH",      # pygrep-hooks
+  "PIE",      # flake8-pie
+  "PL",       # pylint
+  "PT",       # flake8-pytest-style
+  "PTH",      # flake8-use-pathlib
+  "RET",      # flake8-return
+  "RUF",      # Ruff-specific
+  "SIM",      # flake8-simplify
+  "T20",      # flake8-print
+  "UP",       # pyupgrade
+  "YTT",      # flake8-2020
+  "EXE",      # flake8-executable
+  "NPY",      # NumPy specific rules
+  "FURB",     # refurb
+  "PYI",      # flake8-pyi
+]
+# ignore = [
+#   "PLR09",    # Too many <...>
+#   "PLR2004",  # Magic value used in comparison
+#   "ISC001",   # Conflicts with formatter
+# ]
+typing-modules = ["mypackage._compat.typing"]
+isort.required-imports = ["from __future__ import annotations"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["T20"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,8 +75,7 @@ all = ["recast-atlas[local,kubernetes,reana]"]
 # Developer extras
 develop = [
     "pytest>=7.0.0",
-    "flake8>=3.9.0",
-    "black",
+    "ruff",
     "pre-commit",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,9 +105,9 @@ src = ["src"]
 
 [tool.ruff.lint]
 extend-select = [
-  "B",        # flake8-bugbear
+#  "B",        # flake8-bugbear
   "I",        # isort
-  "ARG",      # flake8-unused-arguments
+#  "ARG",      # flake8-unused-arguments
   "C4",       # flake8-comprehensions
   "EM",       # flake8-errmsg
   "ICN",      # flake8-import-conventions
@@ -115,11 +115,11 @@ extend-select = [
   "PGH",      # pygrep-hooks
   "PIE",      # flake8-pie
   "PL",       # pylint
-  "PT",       # flake8-pytest-style
-  "PTH",      # flake8-use-pathlib
-  "RET",      # flake8-return
+#  "PT",       # flake8-pytest-style
+#  "PTH",      # flake8-use-pathlib
+#  "RET",      # flake8-return
   "RUF",      # Ruff-specific
-  "SIM",      # flake8-simplify
+#  "SIM",      # flake8-simplify
   "T20",      # flake8-print
   "UP",       # pyupgrade
   "YTT",      # flake8-2020
@@ -128,11 +128,18 @@ extend-select = [
   "FURB",     # refurb
   "PYI",      # flake8-pyi
 ]
-# ignore = [
-#   "PLR09",    # Too many <...>
-#   "PLR2004",  # Magic value used in comparison
-#   "ISC001",   # Conflicts with formatter
-# ]
+ignore = [
+  "PLR09",    # Too many <...>
+  "PLR2004",  # Magic value used in comparison
+  "ISC001",   # Conflicts with formatter
+  # FIXME:
+  "C414",
+  "EM101",
+  "EM103",
+  "G004",
+  "PLW2901",
+  "T201",
+]
 typing-modules = ["mypackage._compat.typing"]
 isort.required-imports = ["from __future__ import annotations"]
 

--- a/src/recastatlas/backends/__init__.py
+++ b/src/recastatlas/backends/__init__.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 import json
 import logging
-import subprocess
 import os
-import textwrap
 import shlex
-from .. import exceptions
+import subprocess
+import textwrap
+
 from recastatlas.exceptions import BackendNotAvailableException
+
+from .. import exceptions
 
 log = logging.getLogger(__name__)
 
@@ -32,8 +36,7 @@ except (ImportError, exceptions.BackendNotAvailableException):
     pass
 
 try:
-    from .docker import DockerBackend
-    from .docker import setup_docker
+    from .docker import DockerBackend, setup_docker
 
     BACKENDS["docker"] = DockerBackend()
 except (ImportError, exceptions.BackendNotAvailableException):
@@ -56,11 +59,11 @@ def get_shell_packtivity(name, spec, backend):
         return subprocess.check_output(shlex.split(shellcmd)).decode("ascii")
     if backend == "docker":
         command, dockerconfig = setup_docker()
-        script = """\
+        script = f"""\
 mkdir -p ~/.docker
-echo '{dockerconfig}' > ~/.docker/config.json
-{command}
-        """.format(dockerconfig=json.dumps(dockerconfig), command=shellcmd)
+echo '{json.dumps(dockerconfig)}' > ~/.docker/config.json
+{shellcmd}
+        """
         command += ["sh", "-c", textwrap.dedent(script)]
         return subprocess.check_output(command).decode("ascii")
 

--- a/src/recastatlas/backends/__init__.py
+++ b/src/recastatlas/backends/__init__.py
@@ -13,21 +13,21 @@ BACKENDS = {}
 try:
     from .reana import ReanaBackend
 
-    BACKENDS['reana'] = ReanaBackend()
+    BACKENDS["reana"] = ReanaBackend()
 except (ImportError, exceptions.BackendNotAvailableException):
     pass
 
 try:
     from .kubernetes import KubernetesBackend
 
-    BACKENDS['kubernetes'] = KubernetesBackend()
+    BACKENDS["kubernetes"] = KubernetesBackend()
 except (ImportError, exceptions.BackendNotAvailableException):
     pass
 
 try:
     from .local import LocalBackend
 
-    BACKENDS['local'] = LocalBackend()
+    BACKENDS["local"] = LocalBackend()
 except (ImportError, exceptions.BackendNotAvailableException):
     pass
 
@@ -35,7 +35,7 @@ try:
     from .docker import DockerBackend
     from .docker import setup_docker
 
-    BACKENDS['docker'] = DockerBackend()
+    BACKENDS["docker"] = DockerBackend()
 except (ImportError, exceptions.BackendNotAvailableException):
     pass
 
@@ -60,9 +60,7 @@ def get_shell_packtivity(name, spec, backend):
 mkdir -p ~/.docker
 echo '{dockerconfig}' > ~/.docker/config.json
 {command}
-        """.format(
-            dockerconfig=json.dumps(dockerconfig), command=shellcmd
-        )
+        """.format(dockerconfig=json.dumps(dockerconfig), command=shellcmd)
         command += ["sh", "-c", textwrap.dedent(script)]
         return subprocess.check_output(command).decode("ascii")
 

--- a/src/recastatlas/backends/docker.py
+++ b/src/recastatlas/backends/docker.py
@@ -1,12 +1,16 @@
-from ..config import config
-from ..exceptions import FailedRunException
-import logging
-import os
+from __future__ import annotations
+
 import base64
 import json
-import textwrap
+import logging
+import os
 import subprocess
+import textwrap
+
 import yaml
+
+from ..config import config
+from ..exceptions import FailedRunException
 
 log = logging.getLogger(__name__)
 
@@ -103,13 +107,13 @@ class DockerBackend:
         spec["backend"] = spec.get("backend", backend_config)
         command, dockerconfig = setup_docker()
 
-        script = """\
+        script = f"""\
         mkdir -p ~/.docker
-        echo '{dockerconfig}' > ~/.docker/config.json
+        echo '{json.dumps(dockerconfig)}' > ~/.docker/config.json
         cat << 'EOF' | yadage-run -f -
-        {spec}
+        {json.dumps(spec)}
         EOF
-        """.format(spec=json.dumps(spec), dockerconfig=json.dumps(dockerconfig))
+        """
         command += ["sh", "-c", textwrap.dedent(script)]
         subprocess.check_call(command)
 

--- a/src/recastatlas/backends/docker.py
+++ b/src/recastatlas/backends/docker.py
@@ -17,11 +17,11 @@ def setup_docker():
     image = config.backends[backend]["image"]
 
     special_envs = [
-        'PACKTIVITY_CVMFS_LOCATION',
-        'PACKTIVITY_CVMFS_PROPAGATION',
-        'PACKTIVITY_AUTH_LOCATION',
-        'YADAGE_SCHEMA_LOAD_TOKEN',
-        'YADAGE_INIT_TOKEN',
+        "PACKTIVITY_CVMFS_LOCATION",
+        "PACKTIVITY_CVMFS_PROPAGATION",
+        "PACKTIVITY_AUTH_LOCATION",
+        "YADAGE_SCHEMA_LOAD_TOKEN",
+        "YADAGE_INIT_TOKEN",
     ]
     assert special_envs
 
@@ -98,9 +98,9 @@ def setup_docker():
 
 class DockerBackend:
     def run_workflow(self, name, spec):
-        backend_config = config.backends['docker']["fromstring"]
+        backend_config = config.backends["docker"]["fromstring"]
 
-        spec["backend"] = spec.get('backend', backend_config)
+        spec["backend"] = spec.get("backend", backend_config)
         command, dockerconfig = setup_docker()
 
         script = """\
@@ -109,9 +109,7 @@ class DockerBackend:
         cat << 'EOF' | yadage-run -f -
         {spec}
         EOF
-        """.format(
-            spec=json.dumps(spec), dockerconfig=json.dumps(dockerconfig)
-        )
+        """.format(spec=json.dumps(spec), dockerconfig=json.dumps(dockerconfig))
         command += ["sh", "-c", textwrap.dedent(script)]
         subprocess.check_call(command)
 

--- a/src/recastatlas/backends/kubernetes.py
+++ b/src/recastatlas/backends/kubernetes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 

--- a/src/recastatlas/backends/local.py
+++ b/src/recastatlas/backends/local.py
@@ -1,10 +1,14 @@
-from yadage.utils import setupbackend_fromstring
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+
 from yadage.steering_api import run_workflow
+from yadage.utils import setupbackend_fromstring
+
 from ..config import config
 from ..exceptions import FailedRunException
-import logging
-import subprocess
-import os
 
 log = logging.getLogger(__name__)
 

--- a/src/recastatlas/backends/local.py
+++ b/src/recastatlas/backends/local.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 class LocalBackend:
     def run_workflow(self, name, spec):
-        backend_config = config.backends['local']["fromstring"]
+        backend_config = config.backends["local"]["fromstring"]
 
         spec["backend"] = setupbackend_fromstring(
             backend_config, spec.pop("backendopts", {})

--- a/src/recastatlas/backends/reana.py
+++ b/src/recastatlas/backends/reana.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import json
 import logging

--- a/src/recastatlas/backends/reana.py
+++ b/src/recastatlas/backends/reana.py
@@ -33,31 +33,31 @@ def working_directory(path):
 
 class ReanaBackend:
     def __init__(self):
-        self.auth_token = config.backends['reana']['access_token']
-        self.cvmfs_repos = config.backends['reana']['cvmfs_repos']
+        self.auth_token = config.backends["reana"]["access_token"]
+        self.cvmfs_repos = config.backends["reana"]["cvmfs_repos"]
         if not self.check_backend():
-            raise exceptions.BackendNotAvailableException('no REANA auth found')
+            raise exceptions.BackendNotAvailableException("no REANA auth found")
 
     def submit(self, name, spec):
-        wflowname = spec['dataarg']
+        wflowname = spec["dataarg"]
         my_inputs = {
-            "parameters": spec['initdata'],
+            "parameters": spec["initdata"],
         }
 
-        _wflowfile = '_reana_wflow.json'
+        _wflowfile = "_reana_wflow.json"
 
         ping(self.auth_token)
 
         reana_yaml = {
-            'inputs': {'parameters': my_inputs['parameters']},
-            'workflow': {
-                'type': 'yadage',
-                'file': _wflowfile,
-                'resources': {'cvmfs': self.cvmfs_repos},
+            "inputs": {"parameters": my_inputs["parameters"]},
+            "workflow": {
+                "type": "yadage",
+                "file": _wflowfile,
+                "resources": {"cvmfs": self.cvmfs_repos},
             },
         }
 
-        client = get_current_api_client('reana-server')
+        client = get_current_api_client("reana-server")
         d = client.api.create_workflow(
             reana_specification=reana_yaml,
             workflow_name=wflowname,
@@ -65,14 +65,14 @@ class ReanaBackend:
         )
         result = d.response().result
 
-        with open(_wflowfile, 'w') as wflowfile:
+        with open(_wflowfile, "w") as wflowfile:
             wflowspec = yadageschemas.load(
-                spec['workflow'],
+                spec["workflow"],
                 {
-                    'toplevel': spec['toplevel'],
-                    'load_as_ref': False,
-                    'schema_name': 'yadage/workflow-schema',
-                    'schemadir': yadageschemas.schemadir,
+                    "toplevel": spec["toplevel"],
+                    "load_as_ref": False,
+                    "schema_name": "yadage/workflow-schema",
+                    "schemadir": yadageschemas.schemadir,
                 },
                 {},
             )
@@ -84,23 +84,23 @@ class ReanaBackend:
 
         operational_options = {}
 
-        if 'dataopts' in spec and 'initdir' in spec['dataopts']:
-            abs_initdir = os.path.abspath(spec['dataopts']['initdir'].rstrip('/'))
-            base_initdir = os.path.basename(spec['dataopts']['initdir'].rstrip('/'))
+        if "dataopts" in spec and "initdir" in spec["dataopts"]:
+            abs_initdir = os.path.abspath(spec["dataopts"]["initdir"].rstrip("/"))
+            base_initdir = os.path.basename(spec["dataopts"]["initdir"].rstrip("/"))
             with working_directory(os.path.dirname(abs_initdir)):
-                log.debug('uploading dir {abs_initdir}')
+                log.debug("uploading dir {abs_initdir}")
                 upload_to_server(wflowname, [abs_initdir], self.auth_token)
-            operational_options['initdir'] = base_initdir
+            operational_options["initdir"] = base_initdir
 
         start_workflow(
-            wflowname, self.auth_token, {'operational_options': operational_options}
+            wflowname, self.auth_token, {"operational_options": operational_options}
         )
 
         return result
 
     def check_workflow(self, submission):
         status_details = get_workflow_status(
-            submission['submission']['workflow_id'], self.auth_token
+            submission["submission"]["workflow_id"], self.auth_token
         )
         return status_details
 
@@ -108,6 +108,6 @@ class ReanaBackend:
         try:
             assert self.auth_token
             result = ping(self.auth_token)
-            return not (result['error'])
+            return not (result["error"])
         except Exception:  # TODO: Specify Exception type
             return False

--- a/src/recastatlas/cli.py
+++ b/src/recastatlas/cli.py
@@ -1,13 +1,16 @@
-import click
+from __future__ import annotations
+
 import logging
 
-from .subcommands.run import run, submit, retrieve, status
-from .subcommands.catalogue import catalogue
+import click
+
 from .subcommands.auth import auth
 from .subcommands.backends import backends
-from .subcommands.testing import testing
+from .subcommands.catalogue import catalogue
 from .subcommands.ci import ci
+from .subcommands.run import retrieve, run, status, submit
 from .subcommands.software import software
+from .subcommands.testing import testing
 
 LOGFORMAT = "%(asctime)s | %(name)20.20s | %(levelname)6s | %(message)s"
 

--- a/src/recastatlas/config.py
+++ b/src/recastatlas/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import glob
 import logging
 import os

--- a/src/recastatlas/config.py
+++ b/src/recastatlas/config.py
@@ -21,7 +21,7 @@ def conf_from_env(var, default=None):
         try:
             return yaml.safe_load(v)
         except Exception:  # TODO: Specify Exception type
-            log.error(f'could not get config from env var {var} (value: {v})')
+            log.error(f"could not get config from env var {var} (value: {v})")
             raise
     return default
 
@@ -29,10 +29,10 @@ def conf_from_env(var, default=None):
 class Config:
     @property
     def default_run_backend(self):
-        return os.environ.get('RECAST_DEFAULT_RUN_BACKEND', 'docker')
+        return os.environ.get("RECAST_DEFAULT_RUN_BACKEND", "docker")
 
     def default_build_backend(self):
-        return os.environ.get('RECAST_DEFAULT_BUILD_BACKEND', 'docker')
+        return os.environ.get("RECAST_DEFAULT_BUILD_BACKEND", "docker")
 
     @property
     def backends(self):
@@ -67,14 +67,14 @@ class Config:
             "kubernetes": {
                 "metadata": {"short_description": "runs on a Kubernetes cluster"},
                 "buildkit_addr": conf_from_env(
-                    "RECAST_KUBERNETES_BUILDKIT_ADDR", 'kube-pod://buildkitd'
+                    "RECAST_KUBERNETES_BUILDKIT_ADDR", "kube-pod://buildkitd"
                 ),
             },
             "reana": {
                 "metadata": {"short_description": "runs on a REANA deployment"},
-                "access_token": conf_from_env('REANA_ACCESS_TOKEN', None),
+                "access_token": conf_from_env("REANA_ACCESS_TOKEN", None),
                 "cvmfs_repos": conf_from_env(
-                    'RECAST_REANA_CVMFS_REPOS', ['atlas.cern.ch', 'atlas-condb.cern.ch']
+                    "RECAST_REANA_CVMFS_REPOS", ["atlas.cern.ch", "atlas-condb.cern.ch"]
                 ),
             },
         }
@@ -96,7 +96,7 @@ class Config:
         files = list(set(files))
         log.debug(files)
         for f in files:
-            log.debug(f'loading catalogue file {f}')
+            log.debug(f"loading catalogue file {f}")
             entry = yaml.safe_load(open(f))
             process_entry(cfg, f, entry)
         return cfg
@@ -112,18 +112,18 @@ def process_entry(cfg, fname, entry, tags=None):
             entry["spec"]["toplevel"] = os.path.realpath(
                 os.path.join(os.path.dirname(fname), "specs")
             )
-            entry['metadata'].setdefault('tags', []).extend(tags or [])
+            entry["metadata"].setdefault("tags", []).extend(tags or [])
         cfg[name] = entry
     elif (entry is not None) and is_index_file(entry):
-        for index_f in entry['recast_catalogue_entries']:
+        for index_f in entry["recast_catalogue_entries"]:
             index_f = os.path.join(os.path.dirname(fname), index_f)
-            log.debug(f'loading catalogue file {index_f}')
+            log.debug(f"loading catalogue file {index_f}")
             index_entry = yaml.safe_load(open(index_f))
-            process_entry(cfg, index_f, index_entry, entry['tags'])
+            process_entry(cfg, index_f, index_entry, entry["tags"])
 
 
 def is_entry_file(entry):
-    schema = jsonschema.Draft7Validator({'required': ['name', 'metadata', 'spec']})
+    schema = jsonschema.Draft7Validator({"required": ["name", "metadata", "spec"]})
     try:
         schema.validate(entry)
     except jsonschema.exceptions.ValidationError:
@@ -133,7 +133,7 @@ def is_entry_file(entry):
 
 def is_index_file(entry):
     schema = jsonschema.Draft7Validator(
-        {'required': ['name', 'tags', 'recast_catalogue_entries']}
+        {"required": ["name", "tags", "recast_catalogue_entries"]}
     )
     try:
         schema.validate(entry)

--- a/src/recastatlas/exceptions.py
+++ b/src/recastatlas/exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class FailedRunException(Exception):
     """
     raised when an a run has not succeeded

--- a/src/recastatlas/resultsextraction.py
+++ b/src/recastatlas/resultsextraction.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import os
+
 import yaml
 
 
@@ -14,8 +17,8 @@ def get_file(filename, backend, load_yaml=False):
             return yaml.safe_load(contents)
         return contents
     elif backend == "kubernetes":
-        from kubernetes import config as k8sconfig
         from kubernetes import client as k8sclient
+        from kubernetes import config as k8sconfig
 
         k8sconfig.load_kube_config()
         r, _, _ = k8sclient.ApiClient().call_api(

--- a/src/recastatlas/subcommands/auth.py
+++ b/src/recastatlas/subcommands/auth.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import shutil
@@ -148,9 +150,7 @@ def write(basedir):
         os.path.join(basedir, "expect_script.sh"),
     )
     click.echo(
-        "Wrote Authentication Data to {} (Note! This includes passwords/tokens)".format(
-            basedir
-        ),
+        f"Wrote Authentication Data to {basedir} (Note! This includes passwords/tokens)",
         err=True,
     )
 
@@ -201,7 +201,7 @@ def check_access_image(image, backend):
         image = image[0]
         tag = "latest"
 
-    spec = """
+    spec = f"""
 process:
     process_type: 'interpolated-script-cmd'
     script: 'echo hello world'
@@ -212,7 +212,7 @@ environment:
     environment_type: 'docker-encapsulated'
     image: {image}
     imagetag: {tag}
-    """.format(image=image, tag=tag)
+    """
 
     testspec = "testimage.yml"
     open(testspec, "w").write(spec)
@@ -220,9 +220,7 @@ environment:
     testingdir = "recast-auth-testing-image"
     click.secho(f"Running test job for accessing image {image}:{tag}")
     click.secho(
-        "Note: if the image {}:{} is not yet available locally, it will be pulled".format(
-            image, tag
-        )
+        f"Note: if the image {image}:{tag} is not yet available locally, it will be pulled"
     )
     click.secho("-" * 20)
     if os.path.exists(testingdir):
@@ -270,7 +268,7 @@ def check_access_xrootd(image, location, backend):
     server = re.search("root://.*.cern.ch/", location).group(0)
     path = location.replace(server, "")
 
-    spec = """
+    spec = f"""
 process:
     process_type: 'interpolated-script-cmd'
     script: |
@@ -286,7 +284,7 @@ environment:
     imagetag: {tag}
     resources:
     - GRIDProxy
-    """.format(image=image, tag=tag, server=server, path=path)
+    """
 
     testspec = "testauth.yml"
     open(testspec, "w").write(spec)
@@ -294,9 +292,7 @@ environment:
     testingdir = "recast-auth-testing"
     click.secho(f"Running test job for accessing file {location}")
     click.secho(
-        "Note: if the image {}:{} is not yet available locally, it will be pulled".format(
-            image, tag
-        )
+        f"Note: if the image {image}:{tag} is not yet available locally, it will be pulled"
     )
     click.secho("-" * 20)
     if os.path.exists(testingdir):

--- a/src/recastatlas/subcommands/auth.py
+++ b/src/recastatlas/subcommands/auth.py
@@ -34,10 +34,10 @@ def auth():
 
 @auth.command(help="show current auth configuration")
 def show():
-    click.echo('Authdir: {}'.format(os.environ.get(envvar['auth_location'], 'not set')))
+    click.echo("Authdir: {}".format(os.environ.get(envvar["auth_location"], "not set")))
 
 
-@auth.command(help='configure authentication')
+@auth.command(help="configure authentication")
 @click.option("-a", "--answer", multiple=True)
 def setup(answer):
     expt = "ATLAS"
@@ -118,10 +118,10 @@ def setup(answer):
     )
 
 
-@auth.command(help='Prepare auth data on-disk for steps requiring them')
+@auth.command(help="Prepare auth data on-disk for steps requiring them")
 @click.option(
     "--basedir",
-    default=os.path.join(os.environ.get('HOME', os.getcwd()), '.recast', 'auth'),
+    default=os.path.join(os.environ.get("HOME", os.getcwd()), ".recast", "auth"),
     show_default=True,
 )
 def write(basedir):
@@ -148,14 +148,14 @@ def write(basedir):
         os.path.join(basedir, "expect_script.sh"),
     )
     click.echo(
-        'Wrote Authentication Data to {} (Note! This includes passwords/tokens)'.format(
+        "Wrote Authentication Data to {} (Note! This includes passwords/tokens)".format(
             basedir
         ),
         err=True,
     )
 
 
-@auth.command(help='Configure REANA with authentication information.')
+@auth.command(help="Configure REANA with authentication information.")
 def reana_setup():
     click.secho(
         "docker run --rm "
@@ -170,7 +170,7 @@ def reana_setup():
     )
 
 
-@auth.command(help='Unset/Remove auth-relevant env vars/directories')
+@auth.command(help="Unset/Remove auth-relevant env vars/directories")
 def destroy():
     if sys.stdout.isatty():
         click.secho("Use eval $(recast auth destroy) to unset the variables", fg="red")
@@ -183,7 +183,7 @@ def destroy():
             shutil.rmtree(auth_loc)
 
 
-@auth.command(help='check access for private images')
+@auth.command(help="check access for private images")
 @click.argument("image", default="gitlab-registry.cern.ch/lheinric/atlasonlytestimages")
 @click.option(
     "--backend",
@@ -212,9 +212,7 @@ environment:
     environment_type: 'docker-encapsulated'
     image: {image}
     imagetag: {tag}
-    """.format(
-        image=image, tag=tag
-    )
+    """.format(image=image, tag=tag)
 
     testspec = "testimage.yml"
     open(testspec, "w").write(spec)
@@ -244,7 +242,7 @@ environment:
     click.secho("Access: {}".format("ok" if log_ok else "not ok"))
 
 
-@auth.command(help='check access to private data')
+@auth.command(help="check access to private data")
 @click.option("--image", default="lukasheinrich/xrootdclient:latest")
 @click.argument(
     "location",
@@ -288,9 +286,7 @@ environment:
     imagetag: {tag}
     resources:
     - GRIDProxy
-    """.format(
-        image=image, tag=tag, server=server, path=path
-    )
+    """.format(image=image, tag=tag, server=server, path=path)
 
     testspec = "testauth.yml"
     open(testspec, "w").write(spec)
@@ -325,7 +321,7 @@ environment:
     click.secho("Access: {}".format("ok" if access_ok else "not ok"))
 
 
-@auth.command(help='configure to use preset on-disk location of auth data')
+@auth.command(help="configure to use preset on-disk location of auth data")
 @click.argument("location")
 def use(location):
     click.secho(

--- a/src/recastatlas/subcommands/backends.py
+++ b/src/recastatlas/subcommands/backends.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 import click
-from ..config import config
-from ..backends import check_backend
+
 from recastatlas.exceptions import BackendNotAvailableException
+
+from ..backends import check_backend
+from ..config import config
 
 
 @click.group(help="The RECAST computational backends.")

--- a/src/recastatlas/subcommands/catalogue.py
+++ b/src/recastatlas/subcommands/catalogue.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import getpass
 import logging
 import os
@@ -51,9 +53,7 @@ def create(name, path):
     with open(recast_file, "w") as f:
         f.write(data)
     click.secho(
-        "New skeleton created at {path}\nRun $(recast catalogue add {path}) to add to the catlogue".format(
-            path=path
-        )
+        f"New skeleton created at {path}\nRun $(recast catalogue add {path}) to add to the catlogue"
     )
 
 

--- a/src/recastatlas/subcommands/catalogue.py
+++ b/src/recastatlas/subcommands/catalogue.py
@@ -42,7 +42,6 @@ def check(name):
 @click.argument("name")
 @click.argument("path")
 def create(name, path):
-
     template_path = files("recastatlas") / "data/templates/helloworld"
     copy_tree(template_path, path)
     recast_file = os.path.join(path, "recast.yml")
@@ -61,8 +60,8 @@ def create(name, path):
 @catalogue.command()
 def paths():
     paths = config.catalogue_paths()
-    out = '\n'.join(['* ' + x for x in paths])
-    click.secho('Paths considered by RECAST:\n--------------------------')
+    out = "\n".join(["* " + x for x in paths])
+    click.secho("Paths considered by RECAST:\n--------------------------")
     click.secho(out)
 
 
@@ -88,7 +87,7 @@ def rm(path):
     filtered_paths = [p for p in paths if p != path]
     filtered_paths = sorted(list(set(filtered_paths)))
     if not filtered_paths:
-        click.secho('unset RECAST_ATLAS_CATALOGUE')
+        click.secho("unset RECAST_ATLAS_CATALOGUE")
     else:
         click.secho("export RECAST_ATLAS_CATALOGUE=" + ":".join(filtered_paths))
 
@@ -104,7 +103,7 @@ def ls():
                 k,
                 v.get("metadata", default_meta)["short_description"],
                 ",".join(list(v.get("example_inputs", {}).keys())),
-                ",".join(v.get("metadata", default_meta).get('tags', [])),
+                ",".join(v.get("metadata", default_meta).get("tags", [])),
             )
         )
 
@@ -122,10 +121,10 @@ description  : {short:20}
 author       : {author}
 toplevel     : {toplevel}
 """.format(
-        author=metadata.get("author", 'N/A'),
+        author=metadata.get("author", "N/A"),
         name=name,
         short=metadata.get("short_description", "N/A"),
-        toplevel=data['spec']['toplevel'],
+        toplevel=data["spec"]["toplevel"],
     )
     click.secho(toprint)
 

--- a/src/recastatlas/subcommands/ci.py
+++ b/src/recastatlas/subcommands/ci.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import click
 
 

--- a/src/recastatlas/subcommands/run.py
+++ b/src/recastatlas/subcommands/run.py
@@ -88,7 +88,7 @@ def run(name, inputdata, example, backend, tag, format_result):
 @click.option("--example", default="default")
 @click.option("--infofile", default=None)
 @click.option("--tag", default=None)
-@click.option("--backend", type=click.Choice(['kubernetes', 'reana']))
+@click.option("--backend", type=click.Choice(["kubernetes", "reana"]))
 def submit(name, inputdata, example, infofile, tag, backend):
     analysis_id = name
     data = config.catalogue[analysis_id]
@@ -116,7 +116,7 @@ def submit(name, inputdata, example, infofile, tag, backend):
                 {
                     "analysis_id": analysis_id,
                     "instance_id": instance_id,
-                    'submission': submission,
+                    "submission": submission,
                 },
                 info,
             )
@@ -124,10 +124,10 @@ def submit(name, inputdata, example, infofile, tag, backend):
 
 @click.command(help="Get the Status of a asynchronous submission")
 @click.option("--infofile", default=None)
-@click.option("--backend", type=click.Choice(['kubernetes', 'reana']))
+@click.option("--backend", type=click.Choice(["kubernetes", "reana"]))
 def status(infofile, backend):
     submission = json.load(open(infofile))
-    instance = submission['instance_id']
+    instance = submission["instance_id"]
     status = check_async(submission, backend=backend)
     click.secho("{}\t{}".format(instance, status["status"]))
 

--- a/src/recastatlas/subcommands/run.py
+++ b/src/recastatlas/subcommands/run.py
@@ -1,11 +1,14 @@
-import click
-import logging
-import yaml
-import uuid
-import json
+from __future__ import annotations
 
+import json
+import logging
+import uuid
+
+import click
+import yaml
+
+from ..backends import check_async, run_async, run_sync
 from ..config import config
-from ..backends import run_sync, run_async, check_async
 from ..resultsextraction import extract_results
 
 log = logging.getLogger(__name__)
@@ -64,9 +67,7 @@ def run(name, inputdata, example, backend, tag, format_result):
 
     if "results" not in data:
         log.info(
-            "No result file specified in config. Check out workdir for {} manually".format(
-                instance_id
-            )
+            f"No result file specified in config. Check out workdir for {instance_id} manually"
         )
         return
 
@@ -76,9 +77,7 @@ def run(name, inputdata, example, backend, tag, format_result):
     else:
         formatted_result = yaml.safe_dump(result, default_flow_style=False)
         click.secho(
-            "\nRECAST result {} {}:\n--------------\n{}".format(
-                name, instance_id, formatted_result
-            )
+            f"\nRECAST result {name} {instance_id}:\n--------------\n{formatted_result}"
         )
 
 
@@ -109,7 +108,7 @@ def submit(name, inputdata, example, infofile, tag, backend):
 
     submission = run_async(instance_id, spec, backend=backend)
 
-    click.secho(f"{str(instance_id)} submitted")
+    click.secho(f"{instance_id!s} submitted")
     if infofile:
         with open(infofile, "w") as info:
             json.dump(
@@ -166,9 +165,7 @@ def retrieve(infofile, name, instance, show_url, tunnel, format_result):
     data = config.catalogue[name]
     if "results" not in data:
         log.info(
-            "No result file specified in config. Check out workdir for {} manually".format(
-                name
-            )
+            f"No result file specified in config. Check out workdir for {name} manually"
         )
         return
     result = extract_results(data["results"], instance, backend=backend)
@@ -177,7 +174,5 @@ def retrieve(infofile, name, instance, show_url, tunnel, format_result):
     else:
         formatted_result = yaml.safe_dump(result, default_flow_style=False)
         click.secho(
-            "\nRECAST result {} {}:\n--------------\n{}".format(
-                name, instance, formatted_result
-            )
+            f"\nRECAST result {name} {instance}:\n--------------\n{formatted_result}"
         )

--- a/src/recastatlas/subcommands/software.py
+++ b/src/recastatlas/subcommands/software.py
@@ -4,42 +4,42 @@ import os
 from ..config import config
 
 
-@click.group(help='Build Container Images for RECAST')
+@click.group(help="Build Container Images for RECAST")
 def software():
     pass
 
 
 @software.command()
-@click.argument('name')
-@click.argument('path', default='.')
+@click.argument("name")
+@click.argument("path", default=".")
 @click.option(
-    '--backend',
-    type=click.Choice(['docker', 'kubernetes']),
+    "--backend",
+    type=click.Choice(["docker", "kubernetes"]),
     default=config.default_build_backend,
 )
-@click.option('--addr', default=config.backends['kubernetes']['buildkit_addr'])
-@click.option('--push/--no-push', default=False)
+@click.option("--addr", default=config.backends["kubernetes"]["buildkit_addr"])
+@click.option("--push/--no-push", default=False)
 def build(path, name, backend, addr, push):
-    image = f'gitlab-registry.cern.ch/recast-atlas/images/{name}'
+    image = f"gitlab-registry.cern.ch/recast-atlas/images/{name}"
     path = os.path.abspath(path)
-    if backend == 'kubernetes':
+    if backend == "kubernetes":
         subprocess.check_call(
             [
-                'buildctl',
-                '--addr',
+                "buildctl",
+                "--addr",
                 addr,
-                'build',
-                '--frontend',
-                'dockerfile.v0',
-                '--local',
-                f'context={path}',
-                '--local',
-                f'dockerfile={path}',
-                '--output',
-                'type=image,name={},push={}'.format(image, 'true' if push else 'false'),
+                "build",
+                "--frontend",
+                "dockerfile.v0",
+                "--local",
+                f"context={path}",
+                "--local",
+                f"dockerfile={path}",
+                "--output",
+                "type=image,name={},push={}".format(image, "true" if push else "false"),
             ]
         )
-    elif backend == 'docker':
-        subprocess.check_call(['docker', 'build', '-t', image, path])
+    elif backend == "docker":
+        subprocess.check_call(["docker", "build", "-t", image, path])
         if push:
-            subprocess.check_call(['docker', 'push', image])
+            subprocess.check_call(["docker", "push", image])

--- a/src/recastatlas/subcommands/software.py
+++ b/src/recastatlas/subcommands/software.py
@@ -1,6 +1,10 @@
-import click
-import subprocess
+from __future__ import annotations
+
 import os
+import subprocess
+
+import click
+
 from ..config import config
 
 

--- a/src/recastatlas/subcommands/testing.py
+++ b/src/recastatlas/subcommands/testing.py
@@ -1,7 +1,11 @@
-import click
+from __future__ import annotations
+
 import uuid
+
+import click
+
 from ..config import config
-from ..testing import run_test, get_shell
+from ..testing import get_shell, run_test
 
 
 @click.group(help="Run a test")

--- a/src/recastatlas/testing.py
+++ b/src/recastatlas/testing.py
@@ -1,7 +1,11 @@
-import yadageschemas
+from __future__ import annotations
+
 import logging
 import subprocess
-from .backends import run_sync_packtivity, get_shell_packtivity
+
+import yadageschemas
+
+from .backends import get_shell_packtivity, run_sync_packtivity
 
 log = logging.getLogger(__name__)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,12 @@
-from click.testing import CliRunner
-from recastatlas.cli import recastatlas
-from recastatlas.subcommands.run import run
-from recastatlas.subcommands.catalogue import catalogue
+from __future__ import annotations
+
 import os
+
+from click.testing import CliRunner
+
+from recastatlas.cli import recastatlas
+from recastatlas.subcommands.catalogue import catalogue
+from recastatlas.subcommands.run import run
 
 
 def test_cli():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,14 +15,14 @@ def test_run_hello_world(tmpdir):
     with tmpdir.as_cwd():
         runner = CliRunner()
         test = runner.invoke(
-            run, ['testing/busyboxtest', '--backend', 'local', '--tag', 'hello']
+            run, ["testing/busyboxtest", "--backend", "local", "--tag", "hello"]
         )
         assert test.exit_code == 0
-        assert os.path.exists('recast-hello')
-        assert os.path.exists('recast-hello/world/world.txt')
+        assert os.path.exists("recast-hello")
+        assert os.path.exists("recast-hello/world/world.txt")
 
 
 def test_run_catalogue():
     runner = CliRunner()
-    test = runner.invoke(catalogue, ['ls'])
+    test = runner.invoke(catalogue, ["ls"])
     assert test.exit_code == 0


### PR DESCRIPTION
```
* Use Ruff for linting and formatting.
   - Use Ruff in pre-commit over pyupgrade, black, and flake8.
   - Enable additional linting in pyproject.toml ruff tool section.
   - Remove .flake8 and black config section of pyproject.toml.
   - Use Ruff in lint workflow.
* Disable some recommended Ruff lints.
   - c.f. https://learn.scientific-python.org/development/guides/style/#ruff
* Apply ruff formatting to source code.
* Add Ruff formatting badge to README.
```