### PR TITLE
chore: Add .git-blame-ignore-revs to ignore style in blame view

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# style: Use Ruff for linting and formatting
+3517c21f3ec06727805e4b0d8e49ea292b39ba88


### PR DESCRIPTION
Add a git blame ignore-revs file to automatically ignore commits listed in it from the blame view on GitHub. Include in it style changes added by pre-commit hooks which touch multiple files.

To ignore the commits in the .git-blame-ignore-revs when running `git blame` locally run: `git blame --ignore-revs-file .git-blame-ignore-revs`.

c.f.:
* https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt
* https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view