### PR TITLE
chore: Remove mentions of setuptools build tools

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,6 +3,4 @@ current_version = 0.4.0
 commit = True
 tag = True
 
-[bumpversion:file:setup.cfg]
-
 [bumpversion:file:src/recastatlas/config.py]


### PR DESCRIPTION
* Remove setup.cfg from bump2version.

```
* Remove setup.cfg from bump2version.
* Amends PR https://github.com/recast-hep/recast-atlas/pull/145.
```