### PR TITLE
ci: Add GitHub artifact attestations to package distribution

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -14,10 +14,16 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Python distribution
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
 
     steps:
 
@@ -50,6 +56,16 @@ jobs:
 
     - name: List contents of wheel
       run: python -m zipfile --list dist/recast_atlas-*.whl
+
+    - name: Generate artifact attestation for sdist and wheel
+      # If publishing to TestPyPI or PyPI
+      if: >-
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'recast-hep/recast-atlas')
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'recast-hep/recast-atlas')
+        || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'recast-hep/recast-atlas')
+      uses: actions/attest-build-provenance@534b352d658f90498fd148d231fdbf88f3886a3a # v1.3.1
+      with:
+        subject-path: "dist/recast_atlas-*"
 
     - name: Upload distribution artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
* Add generation of GitHub artifact attestations to built sdist and wheel before upload. c.f.:
   - https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/
   - https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds