### PR TITLE
fix: Allow for shutil.copytree to have existing dirs

### DIFF
--- a/src/recastatlas/subcommands/catalogue.py
+++ b/src/recastatlas/subcommands/catalogue.py
@@ -45,7 +45,7 @@ def check(name):
 @click.argument("path")
 def create(name, path):
     template_path = files("recastatlas") / "data/templates/helloworld"
-    shutil.copytree(template_path, path)
+    shutil.copytree(template_path, path, dirs_exist_ok=True)
     recast_file = os.path.join(path, "recast.yml")
     data = string.Template(open(recast_file).read()).safe_substitute(
         name=name, author=getpass.getuser()


### PR DESCRIPTION
* Add dirs_exist_ok=True to allow the copying operation to continue if it encounters existing directories.
   - c.f. https://docs.python.org/3.12/library/shutil.html#shutil.copytree
   - dirs_exist_ok was added in Python 3.8.
* Amends PR #155.

```
* Add dirs_exist_ok=True to allow the copying operation to continue if
  it encounters existing directories.
   - c.f. https://docs.python.org/3.12/library/shutil.html#shutil.copytree
   - dirs_exist_ok was added in Python 3.8.
* Amends PR https://github.com/recast-hep/recast-atlas/pull/155.
```