### PR TITLE
ci: Publish GitHub attestations only for PyPI builds

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -58,11 +58,8 @@ jobs:
       run: python -m zipfile --list dist/recast_atlas-*.whl
 
     - name: Generate artifact attestation for sdist and wheel
-      # If publishing to TestPyPI or PyPI
-      if: >-
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'recast-hep/recast-atlas')
-        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'recast-hep/recast-atlas')
-        || (github.event_name == 'release' && github.event.action == 'published' && github.repository == 'recast-hep/recast-atlas')
+      # If publishing to PyPI
+      if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'recast-hep/recast-atlas'
       uses: actions/attest-build-provenance@534b352d658f90498fd148d231fdbf88f3886a3a # v1.3.1
       with:
         subject-path: "dist/recast_atlas-*"


### PR DESCRIPTION
Resolves #154 

* TestPyPI distributions are not important enough to have duplicate human readable attestations.