### PR TITLE
Bump python to >= 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "click>=7.0",  # for console scripts
     "jsonschema>=3.0.0",
     "pyyaml>=5.1",  # for parsing CLI options
-    "yadage-schemas>=0.10.7",  # c.f. https://github.com/yadage/yadage-schemas/issues/35
+    "yadage-schemas>=0.11.1",  # >=0.11 caps jsonschema<=4.9.1, needed for stage-dependency desugaring
     "importlib-resources>=5.10; python_version < '3.9'",  # for accessing package filepaths
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"]
 description = "RECAST for ATLAS at the LHC"
 readme = "README.md"
 license = { text = "Apache-2.0" }  # SPDX short identifier
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 authors = [
     { name = "Lukas Heinrich", email = "lukas.heinrich@cern.ch" },
     { name = "Matthew Feickert", email = "matthew.feickert@cern.ch" },
@@ -30,11 +30,10 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Physics",
@@ -42,11 +41,10 @@ classifiers = [
 
 # TODO: Empirically evaluate lower bounds
 dependencies = [
-    "click>=7.0",  # for console scripts
+    "click>=8.4.2",  # for console scripts
     "jsonschema>=3.0.0",
     "pyyaml>=5.1",  # for parsing CLI options
     "yadage-schemas>=0.11.1",  # >=0.11 caps jsonschema<=4.9.1, needed for stage-dependency desugaring
-    "importlib-resources>=5.10; python_version < '3.9'",  # for accessing package filepaths
 ]
 
 [project.scripts]

--- a/src/recastatlas/config.py
+++ b/src/recastatlas/config.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import glob
 import logging
 import os
-
 from importlib.resources import files
 
 import jsonschema

--- a/src/recastatlas/config.py
+++ b/src/recastatlas/config.py
@@ -4,12 +4,7 @@ import glob
 import logging
 import os
 
-try:
-    from importlib.resources import files
-except ImportError:
-    # Support Python 3.8 as importlib.resources added in Python 3.9
-    # https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files
-    from importlib_resources import files
+from importlib.resources import files
 
 import jsonschema
 import yaml

--- a/src/recastatlas/subcommands/auth.py
+++ b/src/recastatlas/subcommands/auth.py
@@ -4,7 +4,6 @@ import os
 import re
 import shutil
 import sys
-
 from importlib.resources import files
 
 import click

--- a/src/recastatlas/subcommands/auth.py
+++ b/src/recastatlas/subcommands/auth.py
@@ -5,12 +5,7 @@ import re
 import shutil
 import sys
 
-try:
-    from importlib.resources import files
-except ImportError:
-    # Support Python 3.8 as importlib.resources added in Python 3.9
-    # https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files
-    from importlib_resources import files
+from importlib.resources import files
 
 import click
 

--- a/src/recastatlas/subcommands/catalogue.py
+++ b/src/recastatlas/subcommands/catalogue.py
@@ -6,12 +6,7 @@ import os
 import shutil
 import string
 
-try:
-    from importlib.resources import files
-except ImportError:
-    # Support Python 3.8 as importlib.resources added in Python 3.9
-    # https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files
-    from importlib_resources import files
+from importlib.resources import files
 
 import click
 import yaml

--- a/src/recastatlas/subcommands/catalogue.py
+++ b/src/recastatlas/subcommands/catalogue.py
@@ -5,7 +5,6 @@ import logging
 import os
 import shutil
 import string
-
 from importlib.resources import files
 
 import click

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ from recastatlas.subcommands.run import run
 def test_cli():
     runner = CliRunner()
     test = runner.invoke(recastatlas)
-    assert test.exit_code == 0
+    assert "Usage:" in test.output
 
 
 def test_run_hello_world(tmpdir):


### PR DESCRIPTION
To make the introduction of snakemake support in #178 quite a bit cleaner, this PR mainly bumps this repository to more recent python versions. As reana supports recent snakemake versions only for python >= 3.11 (see [reana-commons](https://github.com/reanahub/reana-commons/blob/master/setup.py#L43-L47)), I'd like to suggest dropping support for older python versions for simplicity. To make this work, a few small updates in other yadage-related packages are also required.

**PR dependencies:**
- packtivity: https://github.com/yadage/packtivity/pull/128
- yadage: https://github.com/yadage/yadage/pull/136

After new packtivity and yadage releases have been created, this PR will be updated to point to the new releases

**Overview of changes:**
- Support python versions 3.11 to 3.14
- Update `yadage-schema` to latest test 0.11.1 to avoid problems with recent `jsonschema` versions
- Update `click` version and fix `test_cli()` test to take into account changed behaviour in recent `click` versions

Tagging @JaySandesara, @jwuerzinger, @lukasheinrich, @matthewfeickert 